### PR TITLE
Add `dist-workspace.toml` to the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,8 @@ include = [
         "sdist",
         "wheel",
     ] },
+    { path = "dist-workspace.toml", format = [
+        "sdist"
+    ] },
     { path = "LICENSE", format = "sdist" },
 ]


### PR DESCRIPTION
Ensures https://github.com/astral-sh/ruff/pull/17868 works for Python source distributions.