### PR TITLE
Use `TAG_VALUE` instead of `latest` for extra Docker file base

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -190,7 +190,7 @@ jobs:
           # Generate Dockerfile content
           cat <<EOF > Dockerfile
           FROM ${BASE_IMAGE}
-          COPY --from=${TY_BASE_IMG}:latest /ty /usr/local/bin/ty
+          COPY --from=${TY_BASE_IMG}:${TAG_VALUE} /ty /usr/local/bin/ty
           ENTRYPOINT []
           CMD ["/usr/local/bin/ty"]
           EOF


### PR DESCRIPTION
Debugging failed fetch in https://github.com/astral-sh/ty/actions/runs/14847918913/job/41685892238

Previously attempted #43 

Presumably, we don't include the `latest` tag when publishing pre-release versions.