### PR TITLE
Include the raw tag in Docker publish labels

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -129,6 +129,7 @@ jobs:
           # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
           tags: |
             type=pep440,pattern={{ version }},value=${{ fromJson(inputs.plan).announcement_tag }}
+            type=raw,value=${{ fromJson(inputs.plan).announcement_tag }}
             type=pep440,pattern={{ major }}.{{ minor }},value=${{ fromJson(inputs.plan).announcement_tag }}
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -278,6 +279,7 @@ jobs:
           # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
           tags: |
             type=pep440,pattern={{ version }},value=${{ fromJson(inputs.plan).announcement_tag }}
+            type=raw,value=${{ fromJson(inputs.plan).announcement_tag }}
             type=pep440,pattern={{ major }}.{{ minor }},value=${{ fromJson(inputs.plan).announcement_tag }}
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3


### PR DESCRIPTION
In https://github.com/astral-sh/ty/actions/runs/14848358920/job/41687152688, we've published a Python PEP 440 tag but we are trying to consume a Rust version tag later. We could transform the Rust tag into a Python tag, but since `ty version` will report the Rust version tag for pre-releases (and so will the Git tag), we should just _also_ publish a tag for matching Rust pre-release styling.

Follows #44 