### PR TITLE
Bump version to 0.0.0a6

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["cargo:./ruff"]
 packages = ["ty"]
-version = "0.0.0-alpha.5"
+version = "0.0.0-alpha.6"
 
 # Config for 'dist'
 [dist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ty"
-version = "0.0.0a5"
+version = "0.0.0a6"
 requires-python = ">=3.8"
 dependencies = []
 description = "An extremely fast Python type checker, written in Rust."
@@ -83,7 +83,7 @@ required-imports = ["from __future__ import annotations"]
 
 
 [tool.uv.sources]
-rooster-blue = { git = "https://github.com/zanieb/rooster", rev = "1e7eeca" }
+rooster-blue = { git = "https://github.com/zanieb/rooster", rev = "e070bc9" }
 
 [tool.maturin]
 bindings = "bin"
@@ -111,3 +111,4 @@ submodules = ["ruff"]
 required-labels = [{ submodule = "ruff", labels = ["ty"] }]
 version-format = "cargo"
 default-bump-type = "pre"
+trim-title-prefixes = ["[ty]"]

--- a/uv.lock
+++ b/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 [[package]]
 name = "rooster-blue"
 version = "0.0.0"
-source = { git = "https://github.com/zanieb/rooster?rev=1e7eeca#1e7eeca7bf2dbfab24994b9b6cac357fc2834be1" }
+source = { git = "https://github.com/zanieb/rooster?rev=e070bc9#e070bc971564b446557a7f7131b8cdc5091b223e" }
 dependencies = [
     { name = "hishel", version = "0.0.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "hishel", version = "0.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -773,7 +773,7 @@ release = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-release = [{ name = "rooster-blue", git = "https://github.com/zanieb/rooster?rev=1e7eeca" }]
+release = [{ name = "rooster-blue", git = "https://github.com/zanieb/rooster?rev=e070bc9" }]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
Upgrades rooster to support `trim-title-prefixes`
