### PR TITLE
Exclude rust-toolchain.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,6 @@ module-name = "ty"
 python-source = "python"
 strip = true
 include = [
-    { path = "ruff/rust-toolchain.toml", format = [
-        "sdist",
-        "wheel",
-    ] },
     { path = "dist-workspace.toml", format = [
         "sdist",
     ] },


### PR DESCRIPTION
## Summary
The `rust-toolchain.toml` specifies the rust toolchain version that we use for development. 
Consumers of the `ty` package can use any Rust versiono (that meets our MSRV) to build ty from an sdist. 

## Test Plan

Ran `uv build` and verified that the `rust-toolchain.toml` is no longer present in the `sdist` folder. 

I uninstalled all Rust toolchains and verified that `cargo build` re-installs the latest stable version. 

I verified that `cargo build` automatically installs the latest stable if the default Rust toolchain doesn't meet the MSRV.
