### PR TITLE
Move TOML indent size config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,11 +10,8 @@ indent_style = space
 insert_final_newline = true
 indent_size = 2
 
-[*.{rs,py,pyi}]
+[*.{rs,py,pyi,toml}]
 indent_size = 4
 
 [*.md]
 max_line_length = 100
-
-[*.toml]
-indent_size = 4


### PR DESCRIPTION
Move TOML indent size configuration. No need to have separate `indent_size = 4` configurations.