### PR TITLE
minor: fix link to rules docs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -22,7 +22,7 @@ respect-ignore-files = false
 
 Configures the enabled rules and their severity.
 
-See [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/rules.md) for a list of all available rules.
+See [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/reference/rules.md) for a list of all available rules.
 
 Valid severities are:
 


### PR DESCRIPTION
Hi there 👋 

Was going through the docs and noticed the link to `rules` page was probably changed and moved to `/reference`, hence this minor PR!

Thanks for the work
