### PR TITLE
Fix href to rules md file in the configuration description

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -22,7 +22,7 @@ respect-ignore-files = false
 
 Configures the enabled rules and their severity.
 
-See [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/rules.md) for a list of all available rules.
+See [the rules documentation](https://github.com/astral-sh/ty/blob/main/docs/reference/rules.md) for a list of all available rules.
 
 Valid severities are:
 


### PR DESCRIPTION
## Summary

Hey there 👋 
Noticed a href issue when setting up my local installation, this PR fixes the href in `docs/reference/configuration.md`

## Test Plan

Click on the href link in the edited markdown file in the head branch
