### PR TITLE
Fix missing '>' in HTML anchor tags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,7 @@ ty check [OPTIONS] [PATH]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="ty-check--paths"><a href="#ty-check--paths"<code>PATHS</code></a></dt><dd><p>List of files or directories to check [default: the project root]</p>
+<dl class="cli-reference"><dt id="ty-check--paths"><a href="#ty-check--paths"><code>PATHS</code></a></dt><dd><p>List of files or directories to check [default: the project root]</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -125,7 +125,7 @@ ty generate-shell-completion <SHELL>
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="ty-generate-shell-completion--shell"><a href="#ty-generate-shell-completion--shell"<code>SHELL</code></a></dt></dl>
+<dl class="cli-reference"><dt id="ty-generate-shell-completion--shell"><a href="#ty-generate-shell-completion--shell"><code>SHELL</code></a></dt></dl>
 
 <h3 class="cli-reference">Options</h3>
 


### PR DESCRIPTION
## Summary

This PR fixes HTML syntax errors in the CLI documentation by adding missing closing angle brackets ('>') in anchor tags. While these missing brackets don't affect the rendered output, fixing them improves HTML validity and maintainability of the documentation.

Changes:
- Add missing '>' after href attributes in anchor tags in docs/reference/cli.md
- Affects documentation formatting only, no functional changes

## Test Plan

Verified the changes by:
1. Checking the rendered markdown locally to ensure the documentation appears identical
2. Validating the HTML syntax of the modified anchor tags
3. Confirming the links still work correctly in the documentation

The changes are purely syntactical and don't affect the functionality or appearance of the documentation.