### PR TITLE
Use Cargo-style versions in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.1a2
+## 0.0.1-alpha.2
 
 ### Enhancements
 
@@ -41,7 +41,7 @@
 - [@sharkdp](https://github.com/sharkdp)
 - [@eruditmorina](https://github.com/eruditmorina)
 
-## 0.0.1a1
+## 0.0.1-alpha.1
 
 ### Enhancements
 
@@ -89,7 +89,7 @@
 - [@mtshiba](https://github.com/mtshiba)
 - [@sharkdp](https://github.com/sharkdp)
 
-## 0.0.0a8
+## 0.0.0-alpha.8
 
 ### Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ required-imports = ["from __future__ import annotations"]
 
 
 [tool.uv.sources]
-rooster-blue = { git = "https://github.com/zanieb/rooster", rev = "84ac1a94101a116363a628973b79abe88220b6cf" }
+rooster-blue = { git = "https://github.com/zanieb/rooster", rev = "cf27242" }
 
 [tool.maturin]
 bindings = "bin"

--- a/uv.lock
+++ b/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 [[package]]
 name = "rooster-blue"
 version = "0.0.0"
-source = { git = "https://github.com/zanieb/rooster?rev=84ac1a94101a116363a628973b79abe88220b6cf#84ac1a94101a116363a628973b79abe88220b6cf" }
+source = { git = "https://github.com/zanieb/rooster?rev=cf27242#cf27242c62fba2cf2ad6d48d58d8f49a2dcb7704" }
 dependencies = [
     { name = "hishel", version = "0.0.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "hishel", version = "0.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -773,7 +773,7 @@ release = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-release = [{ name = "rooster-blue", git = "https://github.com/zanieb/rooster?rev=84ac1a94101a116363a628973b79abe88220b6cf" }]
+release = [{ name = "rooster-blue", git = "https://github.com/zanieb/rooster?rev=cf27242" }]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
Uses https://github.com/zanieb/rooster/pull/70, which should fix dist's changelog -> GitHub Release propagation.