### PR TITLE
[CI] Add check for changes in autogenerated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 * text=auto eol=lf
+
+docs/reference/cli.md linguist-generated=true
+docs/reference/configuration.md linguist-generated=true
+docs/reference/rules.md linguist-generated=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,3 +71,28 @@ jobs:
           exit_code="${PIPESTATUS[0]}"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit "$exit_code"
+
+  generated-check:
+    name: "Check generated files unedited"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+
+      - name: "Run auto generation scripts"
+        run: |
+          ./scripts/autogenerate_files.sh
+
+      - name: "Check for uncommitted changes"
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Error: Auto-generated files were manually edited."
+            echo "Files with changes:"
+            git status --porcelain
+            exit 1
+          fi

--- a/scripts/autogenerate_files.sh
+++ b/scripts/autogenerate_files.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+#
+# Generate files and copy documentation from Ruff.
+#
+# Usage
+#
+#   ./scripts/autogenerate-files.sh
+#
+set -eu
+
+script_root="$(realpath "$(dirname "$0")")"
+project_root="$(dirname "$script_root")"
+cd "$project_root"
+
+echo "Updating lockfile..."
+uv lock
+
+echo "Copying reference documentation from Ruff..."
+cp ruff/crates/ty/docs/cli.md ./docs/reference/
+cp ruff/crates/ty/docs/configuration.md ./docs/reference/
+cp ./ruff/crates/ty/docs/rules.md ./docs/reference/
+
+echo "Documentation has been copied from Ruff submodule"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,11 +46,5 @@ cd "$project_root"
 uv run --only-group release \
     rooster release "$@"
 
-echo "Updating lockfile..."
-uv lock
-
-echo "Copying reference documentation from Ruff..."
-cp ruff/crates/ty/docs/cli.md ./docs/reference/
-cp ruff/crates/ty/docs/configuration.md ./docs/reference/
-cp ./ruff/crates/ty/docs/rules.md ./docs/reference/
+"${script_root}/autogenerate_files.sh"
 git add ./docs/reference


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes: #387 
## Summary
Adds a check for changes in autogenerated files to the CI. 
This PR is taking a similar approach to [ruff](https://github.com/astral-sh/ruff/blob/cf70c7863c2c011367d5fd673332f7fa56ef81ec/.github/workflows/ci.yaml#L499-L503); executing the generation and checking for diffs. 

To have a single place where generation happens, I factored out the generation from `scripts/release.sh` to `scripts/autogenerate_files.sh` and call it in the former.

The scripts ran for me locally, but best have a close look here since I'm not too familiar with the release process. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Local testing by exectuing the `release.sh` script and using [act](https://github.com/nektos/act). 

<!-- How was it tested? -->
