### PR TITLE
Add link to playground to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![PyPI](https://img.shields.io/pypi/v/ty.svg)](https://pypi.python.org/pypi/ty)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/astral-sh)
 
-[**Playground**](https://play.ty.dev/)
-
 An extremely fast Python type checker and language server, written in Rust.
 
 > [!WARNING]
@@ -16,7 +14,8 @@ An extremely fast Python type checker and language server, written in Rust.
 
 ## Getting started
 
-Run ty with [uvx](https://docs.astral.sh/uv/guides/tools/#running-tools) to get started quickly:
+Try out the [online playground](https://play.ty.dev), or run ty with
+[uvx](https://docs.astral.sh/uv/guides/tools/#running-tools) to get started quickly:
 
 ```shell
 uvx ty

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![PyPI](https://img.shields.io/pypi/v/ty.svg)](https://pypi.python.org/pypi/ty)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/astral-sh)
 
+[**Playground**](https://play.ty.dev/)
+
 An extremely fast Python type checker and language server, written in Rust.
 
 > [!WARNING]


### PR DESCRIPTION
The playground is not mentioned anywhere in this repo except in the ISSUE_TEMPLATE.

I added a link to the README in the same place and style as in Ruff repo:

![image](https://github.com/user-attachments/assets/aba1b292-8b29-4a1d-9a02-f06074e120e5)
