### PR TITLE
Add ToC and troubleshooting guidance to detailed README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # ty
 
-**[Installation and basic usage](#installation-and-basic-usage)** |
+**[Installation](#installation)** |
+**[Usage](usage)** |
 **[Module discovery](#module-discovery)** |
 **[Editor integration](#editor-integration)** |
 **[Rules](#rules)** |
@@ -12,7 +13,7 @@
 
 For a quick guide on getting started, see the top-level [README](../README.md#getting-started).
 
-## Installation and basic usage
+## Installation
 
 ### Adding ty to your project
 
@@ -54,7 +55,7 @@ Install ty into your current Python environment with pip:
 pip install ty
 ```
 
-### Running ty
+### Usage
 
 Run [`ty check`](./reference/cli.md#ty-check), in your project's top-level directory,
 to check the project for type errors using ty's default configuration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@
 **[Exit codes](#exit-codes)** |
 **[Reference](#reference)**
 
-
 ## Getting started
+
 For a quick guide on getting started, see the top-level [README](../README.md#getting-started).
 
 ## Installation

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,14 +10,11 @@
 
 
 ## Getting started
-
 For a quick guide on getting started, see the top-level [README](../README.md#getting-started).
 
 ## Installation
 
 ### Adding ty to your project
-
-Your project must use git for source control.
 
 Use [uv](https://github.com/astral-sh/uv) (or your project manager of choice) to add ty as a
 development dependency:
@@ -62,8 +59,9 @@ pip install ty
 Run [`ty check`](./reference/cli.md#ty-check), in your project's top-level directory,
 to check the project for type errors using ty's default configuration.
 
-If this provokes a cascade of errors, and you are using `venv` for a virtual environment, add
-the venv directory to your `.gitignore` and then retry.
+If this provokes a cascade of errors, and you are using the standard library `venv` module
+to provide your virtual environment, add the venv directory to your `.gitignore`
+or `.ignore` file and then retry.
 
 ## Module discovery
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,14 @@
 # ty
 
+**[Installation](#installation)** |
+**[Module discovery](#module-discovery)** |
+**[Editor integration](#editor-integration)** |
+**[Rules](#rules)** |
+**[Suppressions](#suppressions)** |
+**[Exit codes](#exit-codes)** |
+**[Reference](#reference)**
+
+
 ## Getting started
 
 For a quick guide on getting started, see the top-level [README](../README.md#getting-started).
@@ -7,6 +16,8 @@ For a quick guide on getting started, see the top-level [README](../README.md#ge
 ## Installation
 
 ### Adding ty to your project
+
+Your project must use git for source control.
 
 Use [uv](https://github.com/astral-sh/uv) (or your project manager of choice) to add ty as a
 development dependency:
@@ -45,6 +56,14 @@ Install ty into your current Python environment with pip:
 ```shell
 pip install ty
 ```
+
+### Running ty
+
+Run [`ty check`](./reference/cli.md#ty-check), in your project's top-level directory,
+to check the project for type errors using ty's default configuration.
+
+If this provokes a cascade of errors, and you are using `venv` for a virtual environment, add
+the venv directory to your `.gitignore` and then retry.
 
 ## Module discovery
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # ty
 
-**[Installation](#installation)** |
+**[Installation and basic usage](#installation-and-basic-usage)** |
 **[Module discovery](#module-discovery)** |
 **[Editor integration](#editor-integration)** |
 **[Rules](#rules)** |
@@ -12,7 +12,7 @@
 
 For a quick guide on getting started, see the top-level [README](../README.md#getting-started).
 
-## Installation
+## Installation and basic usage
 
 ### Adding ty to your project
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Add troubleshooting guidance and a table of contents to ty detailed README and installation instructions. This improves documentation navigability and, by incorporating advice from @AlexWaygood, helps prevent or remediate an error I stumbled into while testing ty at the PyCon US 2025 sprints.

## Test Plan

I previewed the Markdown file on GitHub and manually checked the formatting and hyperlinks.