### PR TITLE
Clarify `ty check` output format default in CLI doc

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,7 +51,7 @@ ty check [OPTIONS] [PATH]...
 </dd><dt id="ty-check--output-format"><a href="#ty-check--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dd><p>The format to use for printing diagnostic messages</p>
 <p>Possible values:</p>
 <ul>
-<li><code>full</code>:  Print diagnostics verbosely, with context and helpful hints</li>
+<li><code>full</code>:  Print diagnostics verbosely, with context and helpful hints [default]</li>
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
 </ul></dd><dt id="ty-check--project"><a href="#ty-check--project"><code>--project</code></a> <i>project</i></dt><dd><p>Run the command within the given project directory.</p>
 <p>All <code>pyproject.toml</code> files will be discovered by walking up the directory tree from the given project directory, as will the project's virtual environment (<code>.venv</code>) unless the <code>venv-path</code> option is set.</p>


### PR DESCRIPTION
## Summary

Add a "[default]" note in the CLI documentation to indicate that, by default, `ty check` prints "full" diagnostic output, not "concise" output.

## Test Plan

I pushed the branch, and read the preview of the Markdown file on GitHub in my browser.