### PR TITLE
Fix anchor tag in `README` ToC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # ty
 
 **[Installation](#installation)** |
-**[Usage](usage)** |
+**[Usage](#usage)** |
 **[Module discovery](#module-discovery)** |
 **[Editor integration](#editor-integration)** |
 **[Rules](#rules)** |


### PR DESCRIPTION
## Summary

Fix "Usage" anchor link in table of contents in `README`. Followup to #464 which introduced the ToC; during revisions, I accidentally omitted the anchor syntax.

## Test Plan

Previewed [web view of author's branch](https://github.com/brainwane/ty/tree/ToC-fix/docs) in browser on GitHub.