### PR TITLE
Contributor guide: document sources of autogenerated reference docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,17 @@ located in the [Ruff](https://github.com/astral-sh/ruff) repository. While the r
 two projects will evolve over time, they currently share foundational crates and it's easiest to use a single
 repository for the Rust development.
 
+ty's command-line help text, and part of `docs/reference/`, are auto-generated from Rust code in the Ruff
+repository, using generation scripts that live in
+[`crates/ruff_dev/src/`](https://github.com/astral-sh/ruff/blob/main/crates/ruff_dev/src/):
+
+- [Configuration options](docs/reference/configuration.md), from
+    [ruff/crates/ty_project/src/metadata/options.rs](https://github.com/astral-sh/ruff/blob/main/crates/ty_project/src/metadata/options.rs)
+- [Rules](docs/reference/rules.md), from
+    [ruff/crates/ty_python_semantic/src/](https://github.com/astral-sh/ruff/blob/main/crates/ty_python_semantic/src/)
+- [Command-line interface reference](docs/reference/cli.md), from
+    [ruff/crates/ty/src/args.rs](https://github.com/astral-sh/ruff/blob/main/crates/ty/src/args.rs)
+
 The Ruff repository is included as a submodule inside this repository to allow ty's release tags to reflect
 an exact snapshot of the Ruff project. The submodule is only updated on release. To see the latest development
 code, check out the `main` branch of the Ruff repository.


### PR DESCRIPTION
## Summary

Explain in `CONTRIBUTING.md` that some ty help text and reference documentation result from source code that lives in Ruff, and point to sources, to help tech writer contributors.

Inspired by my stumble in #478 and subsequent pointers in https://github.com/astral-sh/ruff/pull/18246 .

## Test Plan

I used `git grep` to search the Ruff repository for several chunks of the prose in `docs/reference/` to verify which source code contains text that turns into the autogenerated docs. I pushed my branch to GitHub and manually checked that the formatting and hyperlinks were correct.