### PR TITLE
Update docs README for Python version inference from environment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -155,12 +155,12 @@ By default, the lower bound of the project's [`requires-python`](https://packagi
 used as the target Python version, ensuring that features and symbols only available in newer Python
 versions are not used.
 
-If the `requires-python` field is not available, however, but a virtual environment has been
+If the `requires-python` field is not available but a virtual environment *has* been
 configured or detected, ty will try to infer the Python version being used from the virtual
 environment's metadata.
 
 If no virtual environment is present or inferring the Python version from the metadata fails,
-applies, ty will fall back to the latest stable Python version supported by ty (currently 3.13).
+ty will fall back to the latest stable Python version supported by ty (currently 3.13).
 
 The Python version may also be explicitly specified using the
 [`python-version`](./reference/configuration.md#python-version) setting or the

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,16 +151,18 @@ if sys.version_info >= (3, 10):
     print(sys.stdlib_module_names)
 ```
 
-By default, the lower bound of the project's [`requires-python`](<(https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires)>) field (from the `pyproject.toml`) is
+By default, the lower bound of the project's [`requires-python`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires) field (from the `pyproject.toml`) is
 used as the target Python version, ensuring that features and symbols only available in newer Python
 versions are not used.
 
-If the `requires-python` field is not available, the latest stable version supported by ty is used,
-which is currently 3.13.
+If the `requires-python` field is not available, however, but a virtual environment has been
+configured or detected, ty will try to infer the Python version being used from the virtual
+environment's metadata.
 
-ty will not infer the Python version from the Python environment at this time.
+If no virtual environment is present or inferring the Python version from the metadata fails,
+applies, ty will fall back to the latest stable Python version supported by ty (currently 3.13).
 
-The Python version may be explicitly specified using the
+The Python version may also be explicitly specified using the
 [`python-version`](./reference/configuration.md#python-version) setting or the
 [`--python-version`](./reference/cli.md#ty-check--python-version) flag.
 


### PR DESCRIPTION
## Summary

These docs are not autogenerated, so they need to be manually updated following the changes made in github.com/astral-sh/ruff/pull/18057. The wording here is basically the same I used for the reference docs in https://github.com/astral-sh/ruff/pull/18397.

## Test Plan

`uvx pre-commit run -a`
