### PR TITLE
Fix `fstring-type-annotation` example syntax

### DIFF
--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -233,13 +233,13 @@ Static analysis tools like ty can't analyse type annotations that use f-string n
 
 ### Examples
 ```python
-def test(): -> f"int":
+def test() -> f"int":
     ...
 ```
 
 Use instead:
 ```python
-def test(): -> "int":
+def test() -> "int":
     ...
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
The example syntax shown in the documentation for `fstring-type-annotation` has an extra `:` after function declaration which I think is a mistake. There should only be one `:` after return type annotation.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
I installed `ty` using `uv` in a fresh install and tried to go through ty rules one by one. I encountered the syntax error on `fstring-type-annotation` example code.
<!-- How was it tested? -->
