### PR TITLE
Document file exclusion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -168,9 +168,25 @@ The Python version may also be explicitly specified using the
 
 ## Excluding files
 
-By default, ty ignores files listed in an `.ignore` or `.gitignore` file.
+ty automatically discovers all Python files in your project. You can customize where ty searches by using the [`src.include`](./reference/configuration.md#include) and [`src.exclude`](./reference/configuration.md#exclude) settings.
 
-To disable this functionality, set [`respect-ignore-files`](./reference/configuration.md#respect-ignore-files) to `false`.
+For example, with the following configuration, ty checks all Python files in the `src` and `tests` directories except those in the `src/generated` directory:
+
+```toml
+[tool.ty.src]
+include = ["src", "tests"]
+exclude = ["src/generated"]
+```
+
+By default, ty excludes a [variety of commonly ignored directories](./reference/configuration.md#exclude). If you want to include one of these directories, you can do so by adding a negative `exclude`:
+
+```toml
+[tool.ty.src]
+# Remove `build` from the excluded directories.
+exclude = ["!build"]
+```
+
+By default, ty ignores files listed in an `.ignore` or `.gitignore` file. To disable this functionality, set [`respect-ignore-files`](./reference/configuration.md#respect-ignore-files) to `false`.
 
 You may also explicitly pass the paths that ty should check, e.g.:
 
@@ -178,7 +194,28 @@ You may also explicitly pass the paths that ty should check, e.g.:
 ty check src scripts/benchmark.py
 ```
 
-We plan on adding dedicated options for including and excluding files in future releases.
+Paths passed explicitly are checked even if they are otherwise ignored by an `exclude` or ignore file.
+
+### Include and exclude syntax
+
+Both `include` and `exclude` support gitignore like glob patterns:
+
+- `./src/` matches only a directory
+- `./src` matches both files and directories
+- `src` matches files or directories named `src`
+- `*` matches any (possibly empty) sequence of characters (except `/`).
+- `**` matches zero or more path components.
+    This sequence **must** form a single path component, so both `**a` and `b**` are invalid and will result in an error.
+    A sequence of more than two consecutive `*` characters is also invalid.
+- `?` matches any single character except `/`
+- `[abc]` matches any character inside the brackets. Character sequences can also specify ranges of characters, as ordered by Unicode,
+    so e.g. `[0-9]` specifies any character between `0` and `9` inclusive. An unclosed bracket is invalid.
+
+Include patterns are anchored: `src` includes only `<project_root>/src` and not `<project_root>/test/src`. To include any directory named `src`, use a prefix match like so: `**/src`, but note that these can notably slow down the Python file discovery.
+
+Exclude patterns aren't anchored unless they contain a `/`: `venv` excludes any directory named `venv`, e.g. it excludes `<project_root>/venv` and `<project_root>/sub/venv`.
+
+All fields accepting patterns use the reduced portable glob syntax from [PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key), with the addition that characters can be escaped with a backslash.
 
 ## Editor integration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -214,7 +214,8 @@ Both `include` and `exclude` support gitignore like glob patterns:
 
 All patterns are anchored: The pattern `src` only includes `<project_root>/src` but not something like `<project_root>/test/src`. To include any directory named `src`, use the prefix match `**/src`. The same applies for exclude patterns where `src` only excludes `<project_root>/src` but not something like `<project_root>/test/src`.
 
-> [!NOTE] A prefix include pattern like `**/src` can notably slow down the Python file discovery.
+> [!NOTE]
+> A prefix include pattern like `**/src` can notably slow down the Python file discovery.
 
 All fields accepting patterns use the reduced portable glob syntax from [PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key), with the addition that characters can be escaped with a backslash.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,13 @@
 # ty
 
 **[Installation](#installation)** |
-**[Usage](#usage)** |
 **[Module discovery](#module-discovery)** |
+**[Python version](#python-version)** |
+**[Excluding files](#excluding-files)** |
 **[Editor integration](#editor-integration)** |
 **[Rules](#rules)** |
 **[Suppressions](#suppressions)** |
+**[Configuration](#configuration)** |
 **[Exit codes](#exit-codes)** |
 **[Reference](#reference)**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -170,7 +170,7 @@ The Python version may also be explicitly specified using the
 
 ## Excluding files
 
-ty automatically discovers all Python files in your project. You can customize where ty searches by using the [`src.include`](./reference/configuration.md#include) and [`src.exclude`](./reference/configuration.md#exclude) settings.
+ty automatically discovers all Python files in your project. You can customize where ty searches by using the [`src.include`](./reference/configuration.md#include-1) and [`src.exclude`](./reference/configuration.md#exclude-1) settings.
 
 For example, with the following configuration, ty checks all Python files in the `src` and `tests` directories except those in the `src/generated` directory:
 
@@ -180,7 +180,7 @@ include = ["src", "tests"]
 exclude = ["src/generated"]
 ```
 
-By default, ty excludes a [variety of commonly ignored directories](./reference/configuration.md#exclude). If you want to include one of these directories, you can do so by adding a negative `exclude`:
+By default, ty excludes a [variety of commonly ignored directories](./reference/configuration.md#exclude-1). If you want to include one of these directories, you can do so by adding a negative `exclude`:
 
 ```toml
 [tool.ty.src]

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,8 +202,8 @@ Paths passed explicitly are checked even if they are otherwise ignored by an `ex
 
 Both `include` and `exclude` support gitignore like glob patterns:
 
-- `./src/` matches only a directory
-- `./src` matches both files and directories
+- `src/` matches only a directory
+- `src` matches both files and directories
 - `src` matches files or directories named `src`
 - `*` matches any (possibly empty) sequence of characters (except `/`).
 - `**` matches zero or more path components.
@@ -215,7 +215,7 @@ Both `include` and `exclude` support gitignore like glob patterns:
 
 Include patterns are anchored: `src` includes only `<project_root>/src` and not `<project_root>/test/src`. To include any directory named `src`, use a prefix match like so: `**/src`, but note that these can notably slow down the Python file discovery.
 
-Exclude patterns aren't anchored unless they contain a `/`: `venv` excludes any directory named `venv`, e.g. it excludes `<project_root>/venv` and `<project_root>/sub/venv`.
+Unlike include patterns, exclude patterns aren't anchored unless they contain a `/`: `venv` excludes any directory named `venv`, e.g. it excludes `<project_root>/venv` and `<project_root>/sub/venv`.
 
 All fields accepting patterns use the reduced portable glob syntax from [PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key), with the addition that characters can be escaped with a backslash.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,7 +185,7 @@ By default, ty excludes a [variety of commonly ignored directories](./reference/
 ```toml
 [tool.ty.src]
 # Remove `build` from the excluded directories.
-exclude = ["!build"]
+exclude = ["!**/build/"]
 ```
 
 By default, ty ignores files listed in an `.ignore` or `.gitignore` file. To disable this functionality, set [`respect-ignore-files`](./reference/configuration.md#respect-ignore-files) to `false`.
@@ -196,26 +196,25 @@ You may also explicitly pass the paths that ty should check, e.g.:
 ty check src scripts/benchmark.py
 ```
 
-Paths passed explicitly are checked even if they are otherwise ignored by an `exclude` or ignore file.
+Paths that are passed as positional arguments to `ty check` are included even if they would otherwise be ignored through `exclude` filters or an ignore-file.
 
 ### Include and exclude syntax
 
 Both `include` and `exclude` support gitignore like glob patterns:
 
-- `src/` matches only a directory
-- `src` matches both files and directories
-- `src` matches files or directories named `src`
+- `src/` matches a directory (including its contents) named `src`.
+- `src` matches a file or directory (including its contents) named `src`.
 - `*` matches any (possibly empty) sequence of characters (except `/`).
 - `**` matches zero or more path components.
-    This sequence **must** form a single path component, so both `**a` and `b**` are invalid and will result in an error.
+    This sequence **must** form a single path component, so both `./**a` and `./b**/` are invalid and will result in an error.
     A sequence of more than two consecutive `*` characters is also invalid.
 - `?` matches any single character except `/`
 - `[abc]` matches any character inside the brackets. Character sequences can also specify ranges of characters, as ordered by Unicode,
     so e.g. `[0-9]` specifies any character between `0` and `9` inclusive. An unclosed bracket is invalid.
 
-Include patterns are anchored: `src` includes only `<project_root>/src` and not `<project_root>/test/src`. To include any directory named `src`, use a prefix match like so: `**/src`, but note that these can notably slow down the Python file discovery.
+All patterns are anchored: The pattern `src` only includes `<project_root>/src` but not something like `<project_root>/test/src`. To include any directory named `src`, use the prefix match `**/src`. The same applies for exclude patterns where `src` only excludes `<project_root>/src` but not something like `<project_root>/test/src`.
 
-Unlike include patterns, exclude patterns aren't anchored unless they contain a `/`: `venv` excludes any directory named `venv`, e.g. it excludes `<project_root>/venv` and `<project_root>/sub/venv`.
+> [!NOTE] A prefix include pattern like `**/src` can notably slow down the Python file discovery.
 
 All fields accepting patterns use the reduced portable glob syntax from [PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key), with the addition that characters can be escaped with a backslash.
 


### PR DESCRIPTION
## Summary

Document the new `src.include` and `src.exclude` fields (not yet released)

Note: The `include` field is currently missing in the generated docs. It will exist once my overrides PR is merged (it's when I noticed that it's missing). This is hopefully before the next release.
