### PR TITLE
docs: remove experimental section

### DIFF
--- a/docs/reference/editor-settings.md
+++ b/docs/reference/editor-settings.md
@@ -2,24 +2,6 @@
 
 The editor settings supported by ty's language server, as well as the settings specific to [ty's VS Code extension](https://github.com/astral-sh/ty-vscode/).
 
-## `experimental`
-
-### `completions.enable`
-
-Enables ty's experimental support for code completions.
-
-**Default value**: `false`
-
-**Type**: `boolean`
-
-**Example usage**:
-
-```json
-{
-  "ty.experimental.completions.enable": true
-}
-```
-
 ## `logFile`
 
 Path to the file to which the language server writes its log messages. By default, ty writes log messages to stderr.


### PR DESCRIPTION
This was only used to opt into completions. But we're removing the
opt-in in https://github.com/astral-sh/ruff/pull/18650, so let's remove
it from the docs too.

Ref #86
