### PR TITLE
Tell Rooster to ignore PRs labeled with `ci` when generating changelogs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ version-files = [
 ]
 submodules = ["ruff"]
 require-labels = [{ submodule = "ruff", labels = ["ty"] }]
-ignore-labels = ["internal", "testing"]
+ignore-labels = ["internal", "testing", "ci"]
 major-labels = []  # We do not use the major version number yet
 minor-labels = []  # We do not use the minor version number yet
 version-format = "cargo"


### PR DESCRIPTION
A few PRs showed up in the initial version of the changelog for https://github.com/astral-sh/ty/pull/700 because they were labeled with `ci` but not with `internal` or `testing`. We should tell Rooster to ignore PRs with this label, same as we do at Ruff: https://github.com/astral-sh/ruff/blob/c1fed55d51b34e1235f72c610fe4b1700ed76451/pyproject.toml#L110
