### PR TITLE
Improve release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ Releases can only be performed by Astral team members.
 
 Preparation for the release is automated.
 
+1. Checkout the `main` branch and run `git pull upstream main --recurse-submodules --tags`.
+
+1. Create and checkout a new branch for the release.
+
 1. Run `./scripts/release.sh`.
 
     The release script will:


### PR DESCRIPTION
## Summary

The release script initially failed for me when I ran it locally for https://github.com/astral-sh/ty/pull/700, with some somewhat opaque error messages. It seems like I had two problems:

1. Despite my `main` branch locally being up to date with the upstream ty `main` branch, the `ruff` submodule on my `main` branch was not up to date with the `ruff` submodule on the upstream ty `main` branch
2. Similarly, the latest tag I had locally was 0.0.1-alpha.5, which caused an assertion in the release script to fail, as it expected me to have 0.0.1-alpha.11 locally in order to create the 0.0.1-alpha.12 release

This PR updates the release instructions so I won't have to figure this out again 😄