### PR TITLE
Publish documentation on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,3 +261,12 @@ jobs:
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  custom-publish-docs:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -56,7 +56,7 @@ local-artifacts-jobs = ["./build-binaries", "./build-docker"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi"]
 # Post-announce jobs to run in CI
-post-announce-jobs = []
+post-announce-jobs = ["./publish-docs"]
 # Custom permissions for GitHub Jobs
 github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read" } }
 # Whether to install an updater program


### PR DESCRIPTION
Extends #730, separated so we can test publishing the documentation manually before doing so on release.

This is copied from ruff.