### PR TITLE
Use 'origin' as the default remote name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Releases can only be performed by Astral team members.
 
 Preparation for the release is automated.
 
-1. Checkout the `main` branch and run `git pull upstream main --recurse-submodules --tags`.
+1. Checkout the `main` branch and run `git pull origin main --recurse-submodules --tags`.
 
 1. Create and checkout a new branch for the release.
 


### PR DESCRIPTION
We use `origin` as the default remote name elsewhere in this doc, so let's use it here as well?