### PR TITLE
`ty` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ty
 
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![PyPI](https://img.shields.io/pypi/v/ty.svg)](https://pypi.python.org/pypi/ty)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/astral-sh)
 
@@ -63,6 +64,28 @@ to anything in the `ruff` submodule (which includes all of the Rust source code)
 
 See the
 [contributing guide](./CONTRIBUTING.md) for more details.
+
+### Show Your Support
+
+If you're using ty, consider adding the ty badge to your project's `README.md`:
+
+```md
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
+```
+
+...or `README.rst`:
+
+```rst
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json
+    :target: https://github.com/astral-sh/ty
+    :alt: ty
+```
+
+...or, as HTML:
+
+```html
+<a href="https://github.com/astral-sh/ty"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json" alt="ty" style="max-width:100%;"></a>
+```
 
 ## License
 

--- a/assets/badge/v0.json
+++ b/assets/badge/v0.json
@@ -1,0 +1,8 @@
+{
+  "label": "",
+  "message": "ty",
+  "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"48\" height=\"48\"><path d=\"M48 7.7H27.8V0h-24v7.7H0v18.2h3.8v14.3c0 4.3 3.5 7.8 7.8 7.8H48V29.8H27.8v-3.9h12.4c4.3 0 7.8-3.5 7.8-7.8V7.7Z\" fill=\"#46ebe1\"/></svg>",
+  "logoWidth": 10,
+  "labelColor": "grey",
+  "color": "#261230"
+}


### PR DESCRIPTION
It's a bit of a chicken/egg story, but it won't work until after its merged. But if you replace the json url with one to a little gist of mine, you can get a sneak peak:

[![ty](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jorenham/9041990267c10a80730c98bd8b1beef0/raw/c8b626d25c4cc498727cf43803be290e1182c122/v0.json)](https://github.com/astral-sh/ty)

I kept it as close as I could to [ruff's badge](https://github.com/astral-sh/ruff#show-your-support). I slightly modified the svg (removed the redundant `viewbox` and `fill` attributes, and some modest path rounding) to shave off a couple of precious bytes and to make the json somewhat less unreadable.

Anyway, I have no strong personal opinions about it, so don't hestitate to let me know what you think about it.

---

Closes #877
