### PR TITLE
Improve visibility of copy and line separator in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -27,6 +27,7 @@
   --md-primary-fg-color: var(--galaxy);
   --md-typeset-a-color: var(--flare);
   --md-accent-fg-color: var(--cosmic);
+  --md-default-fg-color--lightest: rgba(0, 0, 0, 0.14);
 }
 
 [data-md-color-scheme="astral-dark"] {
@@ -34,6 +35,7 @@
   --md-default-fg-color: var(--white);
   --md-default-fg-color--light: var(--white);
   --md-default-fg-color--lighter: var(--white);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.5);
   --md-primary-fg-color: var(--space);
   --md-primary-bg-color: var(--white);
   --md-accent-fg-color: var(--cosmic);


### PR DESCRIPTION
## Summary

Same as https://github.com/astral-sh/ruff/pull/19630 but for ty's documentation

## Test Plan


<img width="1671" height="923" alt="Screenshot 2025-07-31 at 08 36 40" src="https://github.com/user-attachments/assets/570b2c35-dd1f-46ee-b3d4-b416bd3c1cfb" />
