### PR TITLE
Update editor settings reference with new format

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -16,8 +16,8 @@ For Neovim 0.10 or earlier (with [`nvim-lspconfig`](https://github.com/neovim/nv
 
 ```lua
 require('lspconfig').ty.setup({
-  init_options = {
-    settings = {
+  settings = {
+    ty = {
       -- ty language server settings go here
     }
   }
@@ -29,8 +29,8 @@ For Neovim 0.11+ (with [`vim.lsp.config`](<https://neovim.io/doc/user/lsp.html#v
 ```lua
 -- Optional: Only required if you need to update the language server settings
 vim.lsp.config('ty', {
-  init_options = {
-    settings = {
+  settings = {
+    ty = {
       -- ty language server settings go here
     }
   }

--- a/docs/reference/editor-settings.md
+++ b/docs/reference/editor-settings.md
@@ -4,6 +4,10 @@ The editor settings supported by ty's language server, as well as the settings s
 
 ## `python.ty.disableLanguageServices`
 
+!!! warning "Deprecated"
+
+    This option has been deprecated. Use [`ty.disableLanguageServices`](#disablelanguageservices) instead.
+
 Whether to disable the language services for the ty language server like code completion, hover,
 go to definition, etc.
 
@@ -22,6 +26,69 @@ server for features like code completion, hover, go to definition, etc.
 }
 ```
 
+______________________________________________________________________
+
+## `disableLanguageServices`
+
+Whether to disable the language services for the ty language server like code completion, hover,
+go to definition, etc.
+
+This is useful if you want to use ty exclusively for type checking and want to use another language
+server for features like code completion, hover, go to definition, etc.
+
+**Default value**: `false`
+
+**Type**: `boolean`
+
+**Example usage**:
+
+=== "VS Code"
+
+    ```json
+    {
+      "ty.disableLanguageServices": true
+    }
+    ```
+
+=== "Neovim"
+
+    ```lua
+    require('lspconfig').ty.setup({
+      settings = {
+        ty = {
+          disableLanguageServices = true,
+        },
+      },
+    })
+
+    -- For Neovim 0.11.0 and later:
+    vim.lsp.config('ty', {
+      settings = {
+        ty = {
+          disableLanguageServices = true,
+        },
+      },
+    })
+    ```
+
+=== "Zed"
+
+    ```json
+    {
+      "lsp": {
+        "ty": {
+          "settings": {
+            "ty": {
+              "disableLanguageServices": true
+            }
+          }
+        }
+      }
+    }
+    ```
+
+______________________________________________________________________
+
 ## `diagnosticMode`
 
 Determines the scope of the diagnostics reported by the language server.
@@ -35,11 +102,52 @@ Determines the scope of the diagnostics reported by the language server.
 
 **Example usage**:
 
-```json
-{
-  "ty.diagnosticMode": "workspace"
-}
-```
+=== "VS Code"
+
+    ```json
+    {
+      "ty.diagnosticMode": "workspace"
+    }
+    ```
+
+=== "Neovim"
+
+    ```lua
+    require('lspconfig').ty.setup({
+      settings = {
+        ty = {
+          diagnosticMode = 'workspace',
+        },
+      },
+    })
+
+    -- For Neovim 0.11.0 and later:
+    vim.lsp.config('ty', {
+      settings = {
+        ty = {
+          diagnosticMode = 'workspace',
+        },
+      },
+    })
+    ```
+
+=== "Zed"
+
+    ```json
+    {
+      "lsp": {
+        "ty": {
+          "settings": {
+            "ty": {
+              "diagnosticMode": "workspace"
+            }
+          }
+        }
+      }
+    }
+    ```
+
+______________________________________________________________________
 
 ## `logFile`
 
@@ -51,11 +159,46 @@ Path to the file to which the language server writes its log messages. By defaul
 
 **Example usage**:
 
-```json
-{
-  "ty.logFile": "~/path/to/ty.log"
-}
-```
+=== "VS Code"
+
+    ```json
+    {
+      "ty.logFile": "/path/to/ty.log"
+    }
+    ```
+
+=== "Neovim"
+
+    ```lua
+    require('lspconfig').ty.setup({
+      init_options = {
+        logFile = '/path/to/ty.log',
+      },
+    })
+
+    -- For Neovim 0.11.0 and later:
+    vim.lsp.config('ty', {
+      init_options = {
+        logFile = '/path/to/ty.log',
+      },
+    })
+    ```
+
+=== "Zed"
+
+    ```json
+    {
+      "lsp": {
+        "ty": {
+          "initialization_options": {
+            "logFile": "/path/to/ty.log"
+          }
+        }
+      }
+    }
+    ```
+
+______________________________________________________________________
 
 ## `logLevel`
 
@@ -67,29 +210,46 @@ The log level to use for the language server.
 
 **Example usage**:
 
-```json
-{
-  "ty.logLevel": "debug"
-}
-```
+=== "VS Code"
 
-## `trace.server`
+    ```json
+    {
+      "ty.logLevel": "debug"
+    }
+    ```
 
-The detail level at which messages between the language server and the editor (client) are logged. Refer to the [LSP
-specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue)
-for more information.
+=== "Neovim"
 
-**Default value**: `"off"`
+    ```lua
+    require('lspconfig').ty.setup({
+      init_options = {
+        logLevel = 'debug',
+      },
+    })
 
-**Type**: `"off" | "messages" | "verbose"`
+    -- For Neovim 0.11.0 and later:
+    vim.lsp.config('ty', {
+      init_options = {
+        logLevel = 'debug',
+      },
+    })
+    ```
 
-**Example usage**:
+=== "Zed"
 
-```json
-{
-  "ty.trace.server": "messages"
-}
-```
+    ```json
+    {
+      "lsp": {
+        "ty": {
+          "initialization_options": {
+            "logLevel": "debug"
+          }
+        }
+      }
+    }
+    ```
+
+______________________________________________________________________
 
 ## VS Code specific
 
@@ -114,6 +274,8 @@ Strategy for loading the `ty` executable.
 }
 ```
 
+______________________________________________________________________
+
 ### `interpreter`
 
 A list of paths to Python interpreters. Even though this is a list, only the first interpreter is
@@ -134,6 +296,8 @@ The interpreter path is used to find the `ty` executable when
 }
 ```
 
+______________________________________________________________________
+
 ### `path`
 
 A list of path to `ty` executables.
@@ -150,5 +314,25 @@ The extension uses the first executable that exists. This setting takes preceden
 ```json
 {
   "ty.path": ["/home/user/.local/bin/ty"]
+}
+```
+
+______________________________________________________________________
+
+### `trace.server`
+
+The detail level at which messages between the language server and the editor (client) are logged. Refer to the [LSP
+specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue)
+for more information.
+
+**Default value**: `"off"`
+
+**Type**: `"off" | "messages" | "verbose"`
+
+**Example usage**:
+
+```json
+{
+  "ty.trace.server": "messages"
 }
 ```

--- a/docs/reference/editor-settings.md
+++ b/docs/reference/editor-settings.md
@@ -3,7 +3,7 @@
 The editor settings supported by ty's language server, as well as the settings specific to [ty's VS
 Code extension][ty-vscode].
 
-### `disableLanguageServices`
+## `disableLanguageServices`
 
 Whether to disable the language services for the ty language server like code completion, hover,
 go to definition, etc.
@@ -64,7 +64,7 @@ server for features like code completion, hover, go to definition, etc.
 
 ______________________________________________________________________
 
-### `python.ty.disableLanguageServices`
+## `python.ty.disableLanguageServices`
 
 !!! warning "Deprecated"
 
@@ -90,7 +90,7 @@ language server for features like code completion, hover, go to definition, etc.
 
 ______________________________________________________________________
 
-### `diagnosticMode`
+## `diagnosticMode`
 
 Determines the scope of the diagnostics reported by the language server.
 

--- a/docs/reference/editor-settings.md
+++ b/docs/reference/editor-settings.md
@@ -1,34 +1,14 @@
 # Editor settings
 
-The editor settings supported by ty's language server, as well as the settings specific to [ty's VS Code extension](https://github.com/astral-sh/ty-vscode/).
+The editor settings supported by ty's language server, as well as the settings specific to [ty's VS
+Code extension][ty-vscode].
 
-## `python.ty.disableLanguageServices`
+## Runtime settings
 
-!!! warning "Deprecated"
+These settings define the behavior of the language server while it is running. They can be changed
+dynamically without needing to restart the server.
 
-    This option has been deprecated. Use [`ty.disableLanguageServices`](#disablelanguageservices) instead.
-
-Whether to disable the language services for the ty language server like code completion, hover,
-go to definition, etc.
-
-This is useful if you want to use ty exclusively for type checking and want to use another language
-server for features like code completion, hover, go to definition, etc.
-
-**Default value**: `false`
-
-**Type**: `boolean`
-
-**Example usage**:
-
-```json
-{
-  "python.ty.disableLanguageServices": true
-}
-```
-
-______________________________________________________________________
-
-## `disableLanguageServices`
+### `disableLanguageServices`
 
 Whether to disable the language services for the ty language server like code completion, hover,
 go to definition, etc.
@@ -89,7 +69,33 @@ server for features like code completion, hover, go to definition, etc.
 
 ______________________________________________________________________
 
-## `diagnosticMode`
+### `python.ty.disableLanguageServices`
+
+!!! warning "Deprecated"
+
+    This option has been deprecated. Use [`ty.disableLanguageServices`](#disablelanguageservices) instead.
+
+Whether to disable the language services for the ty language server like code completion, hover,
+go to definition, etc.
+
+This is useful if you want to use ty exclusively for type checking and want to use another language
+server for features like code completion, hover, go to definition, etc.
+
+**Default value**: `false`
+
+**Type**: `boolean`
+
+**Example usage**:
+
+```json
+{
+  "python.ty.disableLanguageServices": true
+}
+```
+
+______________________________________________________________________
+
+### `diagnosticMode`
 
 Determines the scope of the diagnostics reported by the language server.
 
@@ -149,7 +155,13 @@ Determines the scope of the diagnostics reported by the language server.
 
 ______________________________________________________________________
 
-## `logFile`
+## Initialization options
+
+The following settings are the initialization options that can be provided to the language server
+during startup. These settings are static and cannot be changed while the server is running. Any
+change to these settings requires a server restart to take effect.
+
+### `logFile`
 
 Path to the file to which the language server writes its log messages. By default, ty writes log messages to stderr.
 
@@ -200,7 +212,7 @@ Path to the file to which the language server writes its log messages. By defaul
 
 ______________________________________________________________________
 
-## `logLevel`
+### `logLevel`
 
 The log level to use for the language server.
 
@@ -253,7 +265,7 @@ ______________________________________________________________________
 
 ## VS Code specific
 
-The following settings are specific to ty's VS Code extension.
+The following settings are specific to [ty's VS Code extension][ty-vscode].
 
 ### `importStrategy`
 
@@ -336,3 +348,5 @@ for more information.
   "ty.trace.server": "messages"
 }
 ```
+
+[ty-vscode]: https://github.com/astral-sh/ty-vscode/

--- a/docs/reference/editor-settings.md
+++ b/docs/reference/editor-settings.md
@@ -3,11 +3,6 @@
 The editor settings supported by ty's language server, as well as the settings specific to [ty's VS
 Code extension][ty-vscode].
 
-## Runtime settings
-
-These settings define the behavior of the language server while it is running. They can be changed
-dynamically without needing to restart the server.
-
 ### `disableLanguageServices`
 
 Whether to disable the language services for the ty language server like code completion, hover,
@@ -75,11 +70,11 @@ ______________________________________________________________________
 
     This option has been deprecated. Use [`ty.disableLanguageServices`](#disablelanguageservices) instead.
 
-Whether to disable the language services for the ty language server like code completion, hover,
-go to definition, etc.
+Whether to disable the language services that ty provides like code completion, hover, go to
+definition, etc.
 
-This is useful if you want to use ty exclusively for type checking and want to use another language
-server for features like code completion, hover, go to definition, etc.
+This is useful if you want to use ty exclusively for type checking in combination with another
+language server for features like code completion, hover, go to definition, etc.
 
 **Default value**: `false`
 
@@ -155,11 +150,105 @@ Determines the scope of the diagnostics reported by the language server.
 
 ______________________________________________________________________
 
+## VS Code specific
+
+The following settings are specific to [ty's VS Code extension][ty-vscode].
+
+### `importStrategy`
+
+Strategy for loading the `ty` executable.
+
+- `fromEnvironment` finds ty in the environment, falling back to the bundled version
+- `useBundled` uses the version bundled with the extension
+
+**Default value**: `"fromEnvironment"`
+
+**Type**: `"fromEnvironment" | "useBundled"`
+
+**Example usage**:
+
+```json
+{
+  "ty.importStrategy": "useBundled"
+}
+```
+
+______________________________________________________________________
+
+### `interpreter`
+
+A list of paths to Python interpreters. Even though this is a list, only the first interpreter is
+used.
+
+The interpreter path is used to find the `ty` executable when
+[`ty.importStrategy`](#importstrategy) is set to `fromEnvironment`.
+
+**Default value**: `[]`
+
+**Type**: `string[]`
+
+**Example usage**:
+
+```json
+{
+  "ty.interpreter": ["/home/user/.local/bin/python"]
+}
+```
+
+______________________________________________________________________
+
+### `path`
+
+A list of path to `ty` executables.
+
+The extension uses the first executable that exists. This setting takes precedence over the
+[`ty.importStrategy`](#importstrategy) setting.
+
+**Default value**: `[]`
+
+**Type**: `string[]`
+
+**Example usage**:
+
+```json
+{
+  "ty.path": ["/home/user/.local/bin/ty"]
+}
+```
+
+______________________________________________________________________
+
+### `trace.server`
+
+The detail level at which messages between the language server and the editor (client) are logged.
+
+This setting is useful for debugging issues with the language server. Refer to the [troubleshooting
+guide](https://github.com/astral-sh/ty-vscode/blob/6cf16b4e87342a49f2bec1310a730cde8229e1d9/TROUBLESHOOTING.md)
+in [ty's VS Code extension][ty-vscode] for more information.
+
+**Default value**: `"off"`
+
+**Type**: `"off" | "messages" | "verbose"`
+
+**Example usage**:
+
+```json
+{
+  "ty.trace.server": "messages"
+}
+```
+
+______________________________________________________________________
+
 ## Initialization options
 
-The following settings are the initialization options that can be provided to the language server
-during startup. These settings are static and cannot be changed while the server is running. Any
-change to these settings requires a server restart to take effect.
+The following settings are required when ty is initialized in an editor. These settings are
+static so changing them requires restarting the editor to take effect.
+
+For VS Code users, these settings are defined in the `ty.*` namespace as usual, but for other
+editors, they would need to be provided in a separate field of the configuration that corresponds to
+the initialization options. Refer to the examples below for how to set these options in different
+editors.
 
 ### `logFile`
 
@@ -261,92 +350,4 @@ The log level to use for the language server.
     }
     ```
 
-______________________________________________________________________
-
-## VS Code specific
-
-The following settings are specific to [ty's VS Code extension][ty-vscode].
-
-### `importStrategy`
-
-Strategy for loading the `ty` executable.
-
-- `fromEnvironment` finds ty in the environment, falling back to the bundled version
-- `useBundled` uses the version bundled with the extension
-
-**Default value**: `"fromEnvironment"`
-
-**Type**: `"fromEnvironment" | "useBundled"`
-
-**Example usage**:
-
-```json
-{
-  "ty.importStrategy": "useBundled"
-}
-```
-
-______________________________________________________________________
-
-### `interpreter`
-
-A list of paths to Python interpreters. Even though this is a list, only the first interpreter is
-used.
-
-The interpreter path is used to find the `ty` executable when
-[`ty.importStrategy`](#importstrategy) is set to `fromEnvironment`.
-
-**Default value**: `[]`
-
-**Type**: `string[]`
-
-**Example usage**:
-
-```json
-{
-  "ty.interpreter": ["/home/user/.local/bin/python"]
-}
-```
-
-______________________________________________________________________
-
-### `path`
-
-A list of path to `ty` executables.
-
-The extension uses the first executable that exists. This setting takes precedence over the
-[`ty.importStrategy`](#importstrategy) setting.
-
-**Default value**: `[]`
-
-**Type**: `string[]`
-
-**Example usage**:
-
-```json
-{
-  "ty.path": ["/home/user/.local/bin/ty"]
-}
-```
-
-______________________________________________________________________
-
-### `trace.server`
-
-The detail level at which messages between the language server and the editor (client) are logged. Refer to the [LSP
-specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue)
-for more information.
-
-**Default value**: `"off"`
-
-**Type**: `"off" | "messages" | "verbose"`
-
-**Example usage**:
-
-```json
-{
-  "ty.trace.server": "messages"
-}
-```
-
-[ty-vscode]: https://github.com/astral-sh/ty-vscode/
+[ty-vscode]: https://marketplace.visualstudio.com/items?itemName=astral-sh.ty


### PR DESCRIPTION
## Summary

This PR updates the documentation to reflect the changes made in https://github.com/astral-sh/ruff/pull/19614 and https://github.com/astral-sh/ty-vscode/pull/106.

## Test Plan

<details><summary>Screenshot of the new editor settings reference page:</summary>
<p>

<img width="4992" height="3702" alt="image" src="https://github.com/user-attachments/assets/e3afd5a3-8b5b-43c3-addd-e1d6636ab1b7" />

</p>
</details> 
