### PR TITLE
Add documentation for PYTHONPATH config

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -56,3 +56,11 @@ The Python environment may be explicitly configured using the
 [`--python`](./reference/cli.md#ty-check--python) flag.
 
 When setting the environment explicitly, non-virtual environments can be provided.
+
+## PYTHONPATH
+
+Python supports setting the `PYTHONPATH` environment variable to control module lookup
+per-environment.
+
+If ty should read this environment variable for lookup paths
+[`environment.read-python-path`](./reference/configuration.md#read-python-path) should be set to true.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -47,6 +47,22 @@ or pyright's `stubPath` configuration setting.
 extra-paths = ["./shared/my-search-path"]
 ```
 
+### `read-python-path`
+
+Boolean to indicate if ty should read paths found in the `PYTHONPATH` environment variable.
+This may be needed by tools which setup python library paths on a per-shell basis.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.ty.environment]
+read-python-path = true
+```
+
 ---
 
 ### `python`


### PR DESCRIPTION
Add documentation on how to configure ty to read the paths defined in the PYTHONPATH environment variable.

## Summary

I added the ability to find modules from paths defined on PYTHONPATH. I opened a [PR](https://github.com/astral-sh/ruff/pull/20016) in the ruff repo. This is the accompanying documentation changes.

## Test Plan
This is only documentation changes, and was verified by building and reading the documentation locally
