### PR TITLE
Upgrade to the latest rooster commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ required-imports = ["from __future__ import annotations"]
 
 
 [tool.uv.sources]
-rooster-blue = { git = "https://github.com/zanieb/rooster", rev = "cf27242" }
+rooster-blue = { git = "https://github.com/zanieb/rooster", rev = "c24ea11bf3cfea89d6f8c782462cac4313e5e0d6" }
 
 [tool.maturin]
 bindings = "bin"
@@ -113,10 +113,11 @@ version-format = "cargo"
 default-bump-type = "pre"
 trim-title-prefixes = ["[ty]"]
 
-changelog_sections.breaking = "Breaking changes"
-changelog_sections.preview = "Preview features"
-changelog_sections.bug = "Bug fixes"
-changelog_sections.server = "Server"
-changelog_sections.cli = "CLI"
-changelog_sections.configuration = "Configuration"
-changelog_sections.documentation = "Documentation"
+[tool.rooster.section-labels]
+"Breaking changes" = ["breaking"]
+"Preview features" = ["preview"]
+"Bug fixes" = ["bug"]
+"Server" = ["server"]
+"CLI" = ["cli"]
+"Configuration" = ["configuration"]
+"Documentation" = ["documentation"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -714,7 +714,7 @@ wheels = [
 [[package]]
 name = "rooster-blue"
 version = "0.0.0"
-source = { git = "https://github.com/zanieb/rooster?rev=cf27242#cf27242c62fba2cf2ad6d48d58d8f49a2dcb7704" }
+source = { git = "https://github.com/zanieb/rooster?rev=c24ea11bf3cfea89d6f8c782462cac4313e5e0d6#c24ea11bf3cfea89d6f8c782462cac4313e5e0d6" }
 dependencies = [
     { name = "hishel", version = "0.0.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "hishel", version = "0.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -773,7 +773,7 @@ release = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-release = [{ name = "rooster-blue", git = "https://github.com/zanieb/rooster?rev=cf27242" }]
+release = [{ name = "rooster-blue", git = "https://github.com/zanieb/rooster?rev=c24ea11bf3cfea89d6f8c782462cac4313e5e0d6" }]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
Nothing pressing here, but gets us on the `main` branch and uses the same commit as uv.