### PR TITLE
Rooster config: ignore PRs labelled `documentation` or `playground` when generating the changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ version-files = [
 ]
 submodules = ["ruff"]
 require-labels = [{ submodule = "ruff", labels = ["ty"] }]
-ignore-labels = ["internal", "testing", "ci"]
+ignore-labels = ["internal", "testing", "ci", "playground", "documentation"]
 major-labels = []  # We do not use the major version number yet
 minor-labels = []  # We do not use the minor version number yet
 version-format = "cargo"
@@ -117,7 +117,6 @@ trim-title-prefixes = ["[ty]"]
 "Breaking changes" = ["breaking"]
 "Preview features" = ["preview"]
 "Bug fixes" = ["bug"]
-"Server" = ["server"]
+"LSP server" = ["server"]
 "CLI" = ["cli"]
 "Configuration" = ["configuration"]
-"Documentation" = ["documentation"]


### PR DESCRIPTION
We usually omit playground-related changes and docs changes from the ty changelog