### PR TITLE
Ignore `github-actions` bot as a contributor in CHANGELOG

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ ignore-labels = [
     "documentation",
     "release",
 ]
+changelog-ignore-authors = ["github-actions"]
 major-labels = [] # We do not use the major version number yet
 minor-labels = [] # We do not use the minor version number yet
 version-format = "cargo"


### PR DESCRIPTION
Re: https://github.com/astral-sh/ty/pull/1371#discussion_r2436914106

I *think* this should work?

https://github.com/zanieb/rooster/blob/b6dafd2c8dc596680bb9e91a1c52192a5ecc3a9e/src/rooster/_config.py#L43

https://github.com/zanieb/rooster/blob/b6dafd2c8dc596680bb9e91a1c52192a5ecc3a9e/src/rooster/_changelog.py#L278-L282

I don't think we need to exclude dependabot (or renovate) because those PRs are labeled as `internal` anyway.