### PR TITLE
Only add the actual schema in schemastore PRs

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -118,11 +118,11 @@ def update_schemastore(
         commit_url = f"{TY_REPO}/commit/{current_sha}"
         commit_body = f"This updates ty's JSON schema to [{current_sha}]({commit_url})"
         # https://stackoverflow.com/a/22909204/3549270
+        check_call(["git", "add", (src / TY_JSON).as_posix()], cwd=schemastore_path)
         check_call(
             [
                 "git",
                 "commit",
-                "-a",
                 "-m",
                 "Update ty's JSON schema",
                 "-m",


### PR DESCRIPTION
Last time I ran this script, due to what I assume was a `npm` version mismatch, the `package-lock.json` file was updated while running `npm install` in the `schemastore`. Due to the use of `git commit -a`, it was accidentally included in the commit for the semi-automated schemastore PR. The solution here is to only add the actual file that we want to commit.

I'll open similar PRs for the respective scripts in ruff and uv once this is accepted.