### PR TITLE
Add documentation about Zed binary path

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -62,7 +62,7 @@ You can enable ty and disable basedpyright by adding this to your `settings.json
 }
 ```
 
-You can override the `ty` executable Zed uses by setting`lsp.ty.binary` :
+You can override the `ty` executable Zed uses by setting `lsp.ty.binary`:
 
 ```json
 {


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I completely understand if this is not a great change. It isn't amazing that the types are different for vscode and zed.

I found it hard to figure out how to do this in zed, so I hope it could be useful for others.

<img width="1703" height="1090" alt="image" src="https://github.com/user-attachments/assets/13217b69-2bf6-43b2-99b4-9ac6d53ee666" />

<img width="1703" height="1090" alt="image" src="https://github.com/user-attachments/assets/72c233ce-ffee-4a8d-95c8-bec4847514ac" />
