### PR TITLE
Small documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@
 
 An extremely fast Python type checker and language server, written in Rust.
 
-> [!WARNING]
->
-> ty is in preview and is not ready for production use.
->
-> We're working hard to make ty stable and feature-complete, but until then, expect to encounter bugs,
-> missing features, and fatal errors.
-
 ## Getting started
 
 Try out the [online playground](https://play.ty.dev), or run ty with

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -8,7 +8,14 @@ The Astral team maintains an official VS Code extension.
 
 Install the [ty extension](https://marketplace.visualstudio.com/items?itemName=astral-sh.ty) from the VS Code Marketplace.
 
-See the extension's [README](https://github.com/astral-sh/ty-vscode) for more details on usage.
+Then disable the language server from the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) by adding the
+following [setting](https://code.visualstudio.com/docs/python/settings-reference#_intellisense-engine-settings) to your `settings.json` to avoid running two language servers:
+
+```json
+{
+  "python.languageServer": "None"
+}
+```
 
 ## Neovim
 
@@ -109,6 +116,8 @@ ty server
 ```
 
 Refer to your editor's documentation to learn how to connect to an LSP server.
+
+## Customize your experience
 
 See the [editor settings](./reference/editor-settings.md) for more details on configuring the language
 server.

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -60,6 +60,20 @@ even when `type: ignore[code]` is used.
 add_three("one", 5)  # type: ignore
 ```
 
+## Multiple suppressions comments
+
+To suppress a typing error on a line that already has a suppression comment from another tool,
+add the `# ty: ignore` comment to the same line.
+
+For example, to suppress a type error and disable formatting for a specific line:
+
+```python
+result = calculate()  # ty: ignore[invalid-argument-type]  # fmt: skip
+
+# or
+result = calculate()  # fmt: off  # ty: ignore[invalid-argument-type]
+```
+
 ## Unused suppression comments
 
 If the [`unused-ignore-comment`](./reference/rules.md#unused-ignore-comment) rule is enabled, ty


### PR DESCRIPTION
## Summary

* Remove the preview warning. ty is fairly stable at this point and only crashes rarely so that a warning as prominent as the one we used is no longer justified. The alpha version should be sufficient as indicator that ty is still in development.
* Inline the basic setup instructions for VS Code rather than pointing users off the ty documentation
* Document how to use ty's suppression comments alongside suppressions from other tools

Closes https://github.com/astral-sh/ty/issues/1467
