### PR TITLE
pin ruff commit hashes when copying docs

### DIFF
--- a/scripts/autogenerate_files.sh
+++ b/scripts/autogenerate_files.sh
@@ -11,14 +11,23 @@ set -eu
 script_root="$(realpath "$(dirname "$0")")"
 project_root="$(dirname "$script_root")"
 cd "$project_root"
+ruff_commit="$(git -C ruff rev-parse HEAD)"
 
 echo "Updating lockfile..."
 uv lock
 
 echo "Copying reference documentation from Ruff..."
-cp ./ruff/crates/ty/docs/cli.md ./docs/reference/
-cp ./ruff/crates/ty/docs/configuration.md ./docs/reference/
-cp ./ruff/crates/ty/docs/rules.md ./docs/reference/
-cp ./ruff/crates/ty/docs/environment.md ./docs/reference/
+copy_docs() {
+    src="$1"
+    dest="$2"
+    [[ -d "$dest" ]] && dest="$dest/$(basename "$src")"
+    old_url="/github.com/astral-sh/ruff/blob/main/"
+    new_url="/github.com/astral-sh/ruff/blob/$ruff_commit/"
+    sed "s|$old_url|$new_url|g" "$src" > "$dest"
+}
+copy_docs ./ruff/crates/ty/docs/cli.md ./docs/reference/
+copy_docs ./ruff/crates/ty/docs/configuration.md ./docs/reference/
+copy_docs ./ruff/crates/ty/docs/rules.md ./docs/reference/
+copy_docs ./ruff/crates/ty/docs/environment.md ./docs/reference/
 
 echo "Documentation has been copied from Ruff submodule"

--- a/scripts/autogenerate_files.sh
+++ b/scripts/autogenerate_files.sh
@@ -20,7 +20,7 @@ echo "Copying reference documentation from Ruff..."
 copy_docs() {
     src="$1"
     dest="$2"
-    [[ -d "$dest" ]] && dest="$dest/$(basename "$src")"
+    [ -d "$dest" ] && dest="$dest/$(basename "$src")"
     old_url="/github.com/astral-sh/ruff/blob/main/"
     new_url="/github.com/astral-sh/ruff/blob/$ruff_commit/"
     sed "s|$old_url|$new_url|g" "$src" > "$dest"


### PR DESCRIPTION
This is a drive-by fix/idea. I noticed that we're publishing links with line numbers that tend to go stale as the upstream Rust code is edited over time (like most of the "View source" links on [this page](https://docs.astral.sh/ty/reference/rules)). Might be nice to snapshot these when we vendor the `.md` files?