### PR TITLE
Use `npm ci --ignore-scripts` instead of `npm install`

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -90,9 +90,9 @@ def update_schemastore(
         cwd=schemastore_path,
     )
 
-    # Run npm install
+    # Run npm ci
     src = schemastore_path / "src"
-    check_call(["npm", "install"], cwd=schemastore_path)
+    check_call(["npm", "ci", "--ignore-scripts"], cwd=schemastore_path)
 
     # Update the schema and format appropriately
     schema = json.loads(TY_SCHEMA.read_text())


### PR DESCRIPTION
## Summary

This uses `npm ci --ignore-scripts` instead of `npm install`, which is more hermetic/reproducible and also forbids build-time script execution (which none of the deps in SchemaStore should need).

See https://github.com/astral-sh/ruff/pull/21742 and https://github.com/astral-sh/uv/pull/16915 for equivalent changes.

## Test Plan

Identical to the uv change, which I tested locally 🙂 