### PR TITLE
Add support for callout syntax (#1875)

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -8,3 +8,4 @@ mdformat-admon>=2.0.2
 mkdocs-redirects>=1.2.2
 mkdocs-git-revision-date-localized-plugin>=1.3.0
 mkdocs-llmstxt>=0.2.0
+mkdocs-callouts>=1.16.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -87,9 +87,12 @@ mergedeep==1.3.4
 mkdocs==1.6.0
     # via
     #   -r docs/requirements.in
+    #   mkdocs-callouts
     #   mkdocs-git-revision-date-localized-plugin
     #   mkdocs-material
     #   mkdocs-redirects
+mkdocs-callouts==1.16.0
+    # via -r docs/requirements.in
 mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-git-revision-date-localized-plugin==1.3.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,8 @@ site_dir: site/ty
 site_description: ty is an extremely fast Python type checker.
 markdown_extensions:
   - admonition
+  - nl2br
+  - admonition
   - pymdownx.details
   - pymdownx.snippets:
   - pymdownx.magiclink:
@@ -62,6 +64,7 @@ markdown_extensions:
       alternate_style: true
 plugins:
   - search
+  - callouts
   - git-revision-date-localized:
       timezone: UTC # It can only be in UTC unless the ISO time can include timezone.
 extra_css:


### PR DESCRIPTION
This resolves the issue of Markdown callouts not rendering in MkDocs.

I used https://github.com/sondregronas/mkdocs-callouts, which is compatible with the syntax already being used in this specific part of the documentation.

## Before
<img width="1574" height="202" alt="image" src="https://github.com/user-attachments/assets/a98d23cf-d454-45f0-922f-38f5402ca998" />

## After
<img width="1550" height="294" alt="image" src="https://github.com/user-attachments/assets/712a0c5a-8b7e-48d7-b8e4-c308dd8af873" />

## Alternative Solution
An alternative solution would be to not add a new dependency and change the callout syntax in the original code. This was implemented in https://github.com/astral-sh/ruff/pull/21961.

```markdown
!!! warning "Deprecated"
    This option has been deprecated. Use `environment.root` instead.
```
<img width="1548" height="312" alt="image" src="https://github.com/user-attachments/assets/dc76808c-20dc-4cd9-8c70-5b8b226dee04" />


Closes #1875 
