### PR TITLE
Restructure and reduce the README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run ty with [uvx](https://docs.astral.sh/uv/guides/tools/#running-tools) to get 
 uvx ty check
 ```
 
-Or, check out the [online ty playground](https://play.ty.dev) to try it out on a snippet.
+Or, check out the [ty playground](https://play.ty.dev) to try it out in your browser.
 
 To learn more about using ty, see the [documentation](https://docs.astral.sh/ty/).
 


### PR DESCRIPTION
Loosely corresponding to https://github.com/astral-sh/ty/pull/1894 but with more aggressive simplifications.

As with that pull request, this doesn't add a highlights section — I'll do that separately.

[Rendered](https://github.com/astral-sh/ty/tree/zb/ty-docs-readme?tab=readme-ov-file#ty)