### PR TITLE
Link to the typing specification in the "type checking" features page

### DIFF
--- a/docs/features/type-checking.md
+++ b/docs/features/type-checking.md
@@ -220,4 +220,4 @@ reveal_type(LoopingCounter().value)
 (Full example in the [playground](https://play.ty.dev/64400d96-ee1b-48f3-8361-b583dddddf82))
 
 [materializations]: https://typing.python.org/en/latest/spec/concepts.html#materialization
-[python typing documentation]: https://typing.python.org/
+[python typing documentation]: https://typing.python.org/en/latest/spec/index.html


### PR DESCRIPTION
Instead of to the top-level page which does not really seem like what I would want if I was trying to understand supported features?
