### PR TITLE
Add a "type checking" page

### DIFF
--- a/docs/features/type-system.md
+++ b/docs/features/type-system.md
@@ -1,4 +1,4 @@
-# Type checking
+# Type system
 
 You can generally expect ty to support all typing features that are described and specified in the
 [Python typing documentation] (for a detailed overview, please refer to the

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,25 +16,9 @@ Run ty with [uvx](https://docs.astral.sh/uv/guides/tools/#running-tools) to get 
 uvx ty check
 ```
 
-!!! note
+ty will check all Python files in the working directory or project by default.
 
-    ty will run on all Python files in the working directory and or subdirectories. If used from a
-    project, ty will run on all Python files in the project (starting in the directory with the
-    `pyproject.toml`).
-
-You can also provide specific paths to check:
-
-```shell
-uvx ty check example.py
-```
-
-!!! note
-
-    When type checking, ty will find installed packages in the active virtual environment (via
-    `VIRTUAL_ENV`) or discover a virtual environment named `.venv` in the project root or working
-    directory. It will not find packages in non-virtual environments without specifying the target
-    path with `--python`. See the [module discovery](./modules.md) documentation for
-    details.
+See the [type checking](./type-checking.md) documentation for more details.
 
 ## Installation
 

--- a/docs/type-checking.md
+++ b/docs/type-checking.md
@@ -1,0 +1,51 @@
+# Type checking
+
+To run the type checker, use the `check` subcommand:
+
+```shell
+ty check
+```
+
+!!! tip
+
+    If you're in a project, you may need to use `uv run` or activate your virtual environment first
+    for ty to find your dependencies.
+
+## Environment discovery
+
+The type checker needs to discover your installed packages in order to check your use of imported
+dependencies.
+
+ty will find installed packages in the active virtual environment (via `VIRTUAL_ENV`) or discover a
+virtual environment named `.venv` in the project root or working directory. It will not find
+packages in non-virtual environments without specifying the target path with `--python`.
+
+See the [module discovery](./modules.md) documentation for details.
+
+## File selection
+
+ty will run on all Python files in the working directory and or subdirectories. If used from a
+project, ty will run on all Python files in the project (starting in the directory with the
+`pyproject.toml`).
+
+You can also provide specific paths to check:
+
+```shell
+uvx ty check example.py
+```
+
+You can also persistently configure [included and excluded files](./exclusions.md).
+
+## Rule selection and severity
+
+ty's type checking diagnostics are often associated with a rule.
+
+ty's type checking rules can be configured to your project's needs. See the [rules](./rules.md)
+documentation for details.
+
+You can also suppress specific violations of rules using [suppression comments](./suppression.md).
+
+## The type system
+
+To learn more about what makes type checking in ty unique, read about the
+[type system](./features/type-system.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Introduction: index.md
   - Concepts:
       - Installation: installation.md
+      - Type checking: type-checking.md
       - Configuration: configuration.md
       - Module discovery: modules.md
       - Python version: python-version.md
@@ -92,7 +93,7 @@ nav:
       - Suppression: suppression.md
       - Editors: editors.md
   - Features:
-      - Type checking: features/type-checking.md
+      - Type system: features/type-system.md
       - Diagnostics: features/diagnostics.md
       - Language server: features/language-server.md
   - Reference:


### PR DESCRIPTION
[Rendered](https://update-docs-zb-doc-type-chec.docs-119.pages.dev/ty/type-checking/)

I was a bit unhappy that the "Introduction" had to explain concepts like file selection and environment discovery. I also think the "Concepts" sections didn't really make sense as "Installation" -> "Configuration", I wanted a page for _using_ the type checker in between. This adds a new page for "Type checking" and moves some of the content out of the "Introduction". The "Features / Type checking" page is renamed to "Features / Type system" to disambiguate — which I think is more appropriate for the target readers anyway.

I think in the long run, we'll want to add "Guides" and have a "Type checking your project", "Type checking a script", etc., but I think that's out of scope for the beta.