### PR TITLE
Add repair of the benchmark images to the PyPI readme transform

### DIFF
--- a/scripts/transform_readme.py
+++ b/scripts/transform_readme.py
@@ -25,6 +25,13 @@ def main() -> None:
 
     content = Path("README.md").read_text(encoding="utf8")
 
+    # Replace relative src="./..." attributes with absolute GitHub raw URLs.
+    def replace_src(match: re.Match) -> str:
+        path = match.group(1).lstrip("./")
+        return f'src="https://raw.githubusercontent.com/astral-sh/ty/{version}/{path}"'
+
+    content = re.sub(r'src="(\./[^"]+)"', replace_src, content)
+
     # Replace any relative URLs (e.g., `[CONTRIBUTING.md`) with absolute URLs.
     def replace(match: re.Match) -> str:
         url = match.group(1)


### PR DESCRIPTION
```diff
diff --git a/README.md b/README.md
index 2114b0b..9d1eca4 100644
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An extremely fast Python type checker and language server, written in Rust.
 <br />
 
 <p align="center">
-  <img alt="Shows a bar chart with benchmark results." width="500px" src="./docs/assets/ty-benchmark-cli.svg">
+  <img alt="Shows a bar chart with benchmark results." width="500px" src="https://raw.githubusercontent.com/astral-sh/ty/0.0.1-alpha.35/docs/assets/ty-benchmark-cli.svg">
 </p>
 
 <p align="center">
@@ -47,9 +47,9 @@ To learn more about using ty, see the [documentation](https://docs.astral.sh/ty/
 
 ## Installation
 
-To install ty, see the [installation](./installation.md) documentation.
+To install ty, see the [installation](https://github.com/astral-sh/ty/blob/0.0.1-alpha.35/installation.md) documentation.
 
-To add the ty language server to your editor, see the [editor integration](./editors.md) guide.
+To add the ty language server to your editor, see the [editor integration](https://github.com/astral-sh/ty/blob/0.0.1-alpha.35/editors.md) guide.
 
 ## Getting help
 
@@ -65,7 +65,7 @@ at this time. Please [open pull requests](https://github.com/astral-sh/ruff/pull
 to anything in the `ruff` submodule (which includes all of the Rust source code).
 
 See the
-[contributing guide](./CONTRIBUTING.md) for more details.
+[contributing guide](https://github.com/astral-sh/ty/blob/0.0.1-alpha.35/CONTRIBUTING.md) for more details.
 
 ## FAQ
 
@@ -85,7 +85,7 @@ Just "ty", please.
 
 ## License
 
-ty is licensed under the MIT license ([LICENSE](LICENSE) or
+ty is licensed under the MIT license ([LICENSE](https://github.com/astral-sh/ty/blob/0.0.1-alpha.35/LICENSE) or
 <https://opensource.org/licenses/MIT>).
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in ty
```