### PR TITLE
ci(docker): align with ruff/uv build-docker.yml

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -57,9 +57,9 @@ jobs:
         env:
           TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || 'dry-run' }}
         run: |
-          version=$(grep -m 1 "^version = " dist-workspace.toml | sed -e 's/version = "\(.*\)"/\1/g')
+          version=$(grep -m 1 "^version = " pyproject.toml | sed -e 's/version = "\(.*\)"/\1/g')
           if [ "${TAG}" != "${version}" ]; then
-            echo "The input tag does not match the version from dist-workspace.toml:" >&2
+            echo "The input tag does not match the version from pyproject.toml:" >&2
             echo "${TAG}" >&2
             echo "${version}" >&2
             exit 1
@@ -135,7 +135,6 @@ jobs:
           # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
           tags: |
             type=pep440,pattern={{ version }},value=${{ fromJson(inputs.plan).announcement_tag }}
-            type=raw,value=${{ fromJson(inputs.plan).announcement_tag }}
             type=pep440,pattern={{ major }}.{{ minor }},value=${{ fromJson(inputs.plan).announcement_tag }}
 
       - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -170,9 +169,9 @@ jobs:
         # Mapping of base image followed by a comma followed by one or more base tags (comma separated)
         # Note, org.opencontainers.image.version label will use the first base tag (use the most specific tag first)
         image-mapping:
-          - alpine:3.21,alpine3.21,alpine
-          - debian:bookworm-slim,bookworm-slim,debian-slim
-          - buildpack-deps:bookworm,bookworm,debian
+          - alpine:3.23,alpine3.23,alpine
+          - debian:trixie-slim,trixie-slim,debian-slim
+          - buildpack-deps:trixie,trixie,debian
     steps:
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -195,7 +194,7 @@ jobs:
           # Generate Dockerfile content
           cat <<EOF > Dockerfile
           FROM ${BASE_IMAGE}
-          COPY --from=${TY_BASE_IMG}:${TAG_VALUE} /ty /usr/local/bin/ty
+          COPY --from=${TY_BASE_IMG}:latest /ty /usr/local/bin/ty
           ENTRYPOINT []
           CMD ["/usr/local/bin/ty"]
           EOF
@@ -281,7 +280,6 @@ jobs:
           # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
           tags: |
             type=pep440,pattern={{ version }},value=${{ fromJson(inputs.plan).announcement_tag }}
-            type=raw,value=${{ fromJson(inputs.plan).announcement_tag }}
             type=pep440,pattern={{ major }}.{{ minor }},value=${{ fromJson(inputs.plan).announcement_tag }}
 
       - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## Summary

Aligns build-docker.yml with ruff (from [f9afcc4](https://github.com/astral-sh/ruff/blob/f9afcc400ce56b1cc0dd1f20f3910afb0bb37d44/.github/workflows/build-docker.yml)) and uv (from [b918557](https://github.com/astral-sh/uv/blob/b918557ae70b4a1f666433df07a8dc32971ec59e/.github/workflows/build-docker.yml))

1. Changed to read version from pyproject.toml rather than dist-workspace.toml
2. Ensures alpine 3.23 and trixie are used to start ty with an up-to-date base.
3. Fixes tag_value usages to align with ruff and uv usage.

zizmor complained about this block because [zizmor.yml](https://github.com/astral-sh/ruff/blob/19b10993e1bfcdcb0be8fad8b4259a0f504860c6/.github/zizmor.yml) is missing in this repo. It seems better to avoid a blanket ignore so I've kept it despite the differences. This should be a fix done in ruff side.

```yaml
permissions:
  contents: read
  # TODO(zanieb): Ideally, this would be `read` on dry-run but that will require
  # significant changes to the workflow.
  packages: write # zizmor: ignore[excessive-permissions]
```

## Test Plan

Did a release on my fork
* [CI Run](https://github.com/samypr100/ty/actions/runs/20497471638)
* [CI Dry Run](https://github.com/samypr100/ty/actions/runs/20497358071)
* [Released Packages](https://github.com/samypr100/ty/pkgs/container/ty/versions?filters%5Bversion_type%5D=tagged) 