### PR TITLE
update_schemastore.py: Fix actual vs expected revision in log

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -165,7 +165,7 @@ def main() -> None:
 
     if expected_ruff_revision != actual_ruff_revision:
         print(
-            f"The ruff submodule is at {expected_ruff_revision} but main expects {actual_ruff_revision}"
+            f"The ruff submodule is at {actual_ruff_revision} but main expects {expected_ruff_revision}"
         )
         match input(
             "How do you want to proceed (u=reset submodule, n=abort, y=continue)? "


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
 Fix the expected vs actual wording in scripts/update_schemastore.py so the log now reports the commit recorded on main as the expected revision and the checked-out submodule commit as the actual revision.
  
  <!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
