### PR TITLE
Bump shellcheck pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,4 +88,4 @@ repos:
           # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
           # and checks these with shellcheck. This is arguably its most useful feature,
           # but the integration only works if shellcheck is installed
-          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.10.0"
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"


### PR DESCRIPTION
## Summary

This dependency isn't updated by Renovate because Renovate can only update `additional_dependencies` in `.pre-commit-config.yaml` if they're additional Python dependencies for a Python pre-commit hook, or additional node dependencies for a node pre-commit hook. In this case, it's an additional Go dependency for a Go pre-commit hook (x-ref https://github.com/renovatebot/renovate/pull/39469).

## Test Plan

`uvx prek run -a --hook-stage=manual`