### PR TITLE
Fail if maturin produces a PyPI incompatible wheel

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -297,7 +297,7 @@ jobs:
           - target: arm-unknown-linux-musleabihf
             arch: arm
             # This target produces a `linux_armv6l` wheel which PyPI accepts,
-            # but maturin's `--compatibility pypi` flag doesn't recognize it.
+            # but maturin's `--compatibility pypi` flag rejects.
             skip_pypi_validation: true
 
     steps:


### PR DESCRIPTION
When we use automatic manylinux tag determination, we need to ensure that the wheel is uploadable to PyPI or the job will fail downstream and cause a partial release. 