### PR TITLE
Set the manylinux tag explicitly for ppc64 builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -290,10 +290,12 @@ jobs:
             arch: ppc64le
             # see https://github.com/astral-sh/ruff/issues/10073
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+            manylinux: manylinux_2_17
           - target: powerpc64-unknown-linux-gnu
             arch: ppc64
             # see https://github.com/astral-sh/ruff/issues/10073
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+            manylinux: manylinux_2_17
           - target: arm-unknown-linux-musleabihf
             arch: arm
 
@@ -311,7 +313,7 @@ jobs:
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          manylinux: auto
+          manylinux: ${{ matrix.platform.manylinux || 'auto' }}
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1


### PR DESCRIPTION
As of the latest version of maturin, this actually may not be compatible with the manylinux tag, but I think we should continue publishing it until we've made the actual choice to drop support. This is redundant with #2387 which downgrades maturin, but relevant for future upgrades.