### PR TITLE
Always target manylinux 2_17 and better pre-upload checks

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -305,7 +305,8 @@ jobs:
             # see https://github.com/astral-sh/ruff/issues/10073
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: arm-unknown-linux-musleabihf
-            manylinux: musllinux_1_2
+            # Use the cross container, but tag as `linux_armv6l`
+            manylinux: auto
             arch: arm
 
     steps:


### PR DESCRIPTION
We currently build for manylinux_2_17, and if this target changes, it should be an intentional, explicit change.

Closes #2389
Closes https://github.com/astral-sh/ty/issues/2396