### PR TITLE
Declare support for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Rust",
     "Topic :: Software Development :: Quality Assurance",


### PR DESCRIPTION
## Summary

This PR officially declare support for Python 3.14 which I think we do looking at the changelog of 3.14.

Reference: https://docs.python.org/3/whatsnew/3.14.html

- ty always defers annotation on 3.14
- t-strings are supported
- `except` and `except *` are supported without parentheses
- What about https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-finally-syntaxwarning ?
