### PR TITLE
Add `language: golang` to actionlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,7 @@ repos:
         args:
           - "-ignore=SC2129" # ignorable stylistic lint from shellcheck
           - "-ignore=SC2016" # another shellcheck lint: seems to have false positives?
+        language: golang # means renovate will also update `additional_dependencies`
         additional_dependencies:
           # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
           # and checks these with shellcheck. This is arguably its most useful feature,


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add `language: golang` to the pre-commit hook of actionlint. That way, Renovate will update the shellcheck version in `additional_dependencies` in the future (x-ref https://github.com/astral-sh/ty/pull/2262).

See: https://docs.renovatebot.com/modules/manager/pre-commit/#go


## Test Plan

`uvx prek run --all-files --hook-stage=manual`
