### PR TITLE
Stylize 'ty' correctly in zed configuration docs

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -61,7 +61,7 @@ You can enable ty and disable basedpyright by adding this to your `settings.json
   "languages": {
     "Python": {
       "language_servers": [
-        // Disable basedpyright and enable Ty, and otherwise
+        // Disable basedpyright and enable ty, and otherwise
         // use the default configuration.
         "ty",
         "!basedpyright",


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

https://github.com/astral-sh/ty?tab=readme-ov-file#how-should-i-stylize-ty states that we should use "ty" rather than "Ty".

And this has also been changes in the zed docs.

