### PR TITLE
Fix changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Released on 2026-01-09.
 
 ### Configuration
 
-- Enable `unused-type-ignore-comment` by default ([#22474](https://github.com/astral-sh/ruff/pull/22474))
+- Enable `unused-ignore-comment` by default ([#22474](https://github.com/astral-sh/ruff/pull/22474))
 
 ### Performance
 


### PR DESCRIPTION
The rule is called `unused-ignore-comment`, not `unused-type-ignore-comment`

x-ref https://github.com/astral-sh/ruff/pull/22474#issuecomment-3737970080