### PR TITLE
Add `pre-commit` hook for `ty` type checker

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: ty
+  name: ty type checker
+  description: An extremely fast Python type checker and language server, written in Rust.
+  entry: ty check
+  language: python
+  pass_filenames: true
+  types_or:
+    - python


### PR DESCRIPTION
## Summary

This pull request adds a new pre-commit hook for Python type checking using the `ty` tool. This will help ensure type safety in Python code by running fast static analysis before commits. 

## Changes

- Introduce a new `pre-commit` hook configuration for the `ty` type checker.
- Added a new pre-commit hook for the `ty` type checker in `.pre-commit-hooks.yaml` to enable fast Python type checking.
- Define the hook with an entry point `ty check`.
- Specify the language as `python` and enable filename passing.
- Support Python file types for the hook.

## Issues

- #269
- #1733
- #2361

## References

I have followed the instructions given here:
https://pre-commit.com/#creating-new-hooks