### PR TITLE
docs: add llms.txt support

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,10 +66,11 @@ plugins:
       timezone: UTC # It can only be in UTC unless the ISO time can include timezone.
   - llmstxt:
       markdown_description: |
-        ty is an extremely fast Python type checker written in Rust. It can type check
-        large Python codebases in seconds, providing fast feedback during development.
+        ty is an extremely fast Python type checker and a language server written in Rust. 
+        It can type check large Python codebases in seconds, providing fast feedback
+        during development.
 
-        ty includes both a CLI (`ty check`) and a language server for editor integration.
+        ty includes both a CLI (`ty check`) and a language server (`ty server`) for editor integration.
 
         When fetching documentation, use explicit `index.md` paths for directories, e.g.,
         `https://docs.astral.sh/ty/features/index.md`. This returns clean markdown instead


### PR DESCRIPTION
## Summary

Add mkdocs-llmstxt plugin configuration to generate llms.txt for LLM-friendly documentation access.
Matches [uv](https://docs.astral.sh/uv/llms.txt) and [ruff](https://docs.astral.sh/ruff/llms.txt).

See astral-sh/uv#13929 and astral-sh/ruff#22463 for more information.

## Test Plan

1. Serve with
```shell
uvx --with-requirements docs/requirements.txt -- mkdocs serve -f mkdocs.yml
```
2. Inspect http://127.0.0.1:8000/ty/llms.txt

The generated file should look like:
```
# ty

> ty is an extremely fast Python type checker.

ty is an extremely fast Python type checker written in Rust. It can type check
large Python codebases in seconds, providing fast feedback during development.

ty includes both a CLI (`ty check`) and a language server for editor integration.

When fetching documentation, use explicit `index.md` paths for directories, e.g.,
`https://docs.astral.sh/ty/features/index.md`. This returns clean markdown instead
of rendered HTML with JS/CSS.


## Guides

- [Editor integration](http://127.0.0.1:8000/ty/editors/index.md)
- [Installation](http://127.0.0.1:8000/ty/installation/index.md)
- [Type checking](http://127.0.0.1:8000/ty/type-checking/index.md)

## Concepts

- [Configuration](http://127.0.0.1:8000/ty/configuration/index.md)
- [File exclusions](http://127.0.0.1:8000/ty/exclusions/index.md)
- [Module discovery](http://127.0.0.1:8000/ty/modules/index.md)
- [Python version](http://127.0.0.1:8000/ty/python-version/index.md)
- [Rules](http://127.0.0.1:8000/ty/rules/index.md)
- [Suppression](http://127.0.0.1:8000/ty/suppression/index.md)

## Features

- [Diagnostics](http://127.0.0.1:8000/ty/features/diagnostics/index.md)
- [Language server](http://127.0.0.1:8000/ty/features/language-server/index.md)
- [Type system](http://127.0.0.1:8000/ty/features/type-system/index.md)

## Reference

- [CLI](http://127.0.0.1:8000/ty/reference/cli/index.md)
- [Configuration](http://127.0.0.1:8000/ty/reference/configuration/index.md)
- [Editor settings](http://127.0.0.1:8000/ty/reference/editor-settings/index.md)
- [Environment variables](http://127.0.0.1:8000/ty/reference/environment/index.md)
- [Exit codes](http://127.0.0.1:8000/ty/reference/exit-codes/index.md)
- [Rules](http://127.0.0.1:8000/ty/reference/rules/index.md)
- [Typing FAQ](http://127.0.0.1:8000/ty/reference/typing-faq/index.md)
```

Note: the loopback address links are expected when serving locally, and will be replaced with the fully-qualified domain name (i.e. docs.astral.sh) when deployed