### PR TITLE
Fix empty body rule rendering

### DIFF
--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -511,6 +511,7 @@ is unsound, and will lead to ty inferring incorrect types elsewhere.
 
 Functions with empty bodies are permitted in certain contexts where they serve as
 declarations rather than implementations:
+
 - Functions in stub files (`.pyi`)
 - Methods in Protocol classes
 - Abstract methods decorated with `@abstractmethod`


### PR DESCRIPTION
Without the extra newline here, the bullets don't become a list and instead are mashed into the previous paragraph.

Ref: https://docs.astral.sh/ty/reference/rules/#empty-body