### PR TITLE
Fix ty version reporting in Docker distributions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN rustup target add $(cat rust_target.txt)
 COPY ruff/crates crates
 COPY ruff/Cargo.toml Cargo.toml
 COPY ruff/Cargo.lock Cargo.lock
+COPY dist-workspace.toml ../dist-workspace.toml
 RUN cargo zigbuild --bin ty --target $(cat rust_target.txt) --release
 RUN cp target/$(cat rust_target.txt)/release/ty /ty
 # TODO: Optimize binary size, with a version that also works when cross compiling


### PR DESCRIPTION
Closes #2698 

```
❯ docker run --rm ty-test version
ty 0.0.14
```