### PR TITLE
Add instructions for how to run ty with Bazel

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -169,26 +169,8 @@ The following tags are available:
 
 ### Using ty with Bazel
 
-ty is available as a Bazel lint aspect via
-[`aspect_rules_lint`](https://registry.bazel.build/docs/aspect_rules_lint#lint-ty-bzl).
-To use it, add it as a dependency in your `MODULE.bazel` file:
-
-```starlark title="MODULE.bazel"
-bazel_dep(name = "aspect_rules_lint", version = "2.0.0")
-```
-
-Then configure how to run ty in a `.bzl` file using [`lint_ty_aspect`](https://registry.bazel.build/docs/aspect_rules_lint#function-lint_ty_aspect):
-
-```starlark title="tools/lint/linters.bzl"
-load("@aspect_rules_lint//lint:ty.bzl", "lint_ty_aspect")
-
-ty = lint_ty_aspect(
-    binary = Label("@aspect_rules_lint//lint:ty_bin"),
-    config = Label("//:pyproject.toml"),
-)
-```
-
-Finally, see the [`aspect_rules_lint` documentation](https://github.com/aspect-build/rules_lint/blob/main/docs/linting.md) for how to run linting (type checking) with Bazel.
+[`aspect_rules_lint`](https://registry.bazel.build/docs/aspect_rules_lint#function-lint_ty_aspect)
+provides a Bazel lint aspect that runs ty. See its documentation for setup instructions.
 
 ## Adding ty to your editor
 


### PR DESCRIPTION
## Summary

Add instructions for running ty via Bazel (using https://registry.bazel.build/docs/aspect_rules_lint#lint-ty-bzl).

Rendered:

<img width="711" height="517" alt="image" src="https://github.com/user-attachments/assets/fc88d5f9-36ea-4ccd-ae6b-d544d3f659d3" />


closes #2097 