### PR TITLE
docs: Add command configuration for ty in neovim

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -48,7 +48,7 @@ For Neovim 0.11+ (with [`vim.lsp.config`](<https://neovim.io/doc/user/lsp.html#v
 
 ```lua
 vim.lsp.config('ty', {
-  -- Required: Start the ty LSP server
+  -- Required: Start the ty language server
   cmd = { "ty", "server" },
   -- Optional: Only required if you need to update the language server settings
   settings = {


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

For me, `ty` does not work in neovim unless I specify to run the `server` command in the config. Adding it to the docs might be helpful for first time users.

