### PR TITLE
Add attestations for release artifacts and Docker images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -117,6 +117,10 @@ jobs:
     needs:
       - docker-build
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -155,6 +159,26 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${TY_BASE_IMG}@sha256:%s " *)
 
+      - name: Export manifest digest
+        id: manifest-digest
+        env:
+          IMAGE: ${{ env.TY_BASE_IMG }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest="$(
+            docker buildx imagetools inspect \
+              "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}' \
+            | jq -r '.digest'
+          )"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.TY_BASE_IMG }}
+          subject-digest: ${{ steps.manifest-digest.outputs.digest }}
+
   docker-publish-extra:
     name: Publish additional Docker image based on ${{ matrix.image-mapping }}
     runs-on: ubuntu-latest
@@ -163,6 +187,10 @@ jobs:
     needs:
       - docker-publish
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -237,6 +265,7 @@ jobs:
             ${{ env.TAG_PATTERNS }}
 
       - name: Build and push
+        id: build-and-push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
@@ -249,6 +278,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.TY_BASE_IMG }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+
   # This is effectively a duplicate of `docker-publish` to make https://github.com/astral-sh/ty/pkgs/container/ty
   # show the ty base image first since GitHub always shows the last updated image digests
   # This works by annotating the original digests (previously non-annotated) which triggers an update to ghcr.io
@@ -260,6 +295,10 @@ jobs:
     needs:
       - docker-publish-extra
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -303,3 +342,23 @@ jobs:
             "${annotations[@]}" \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${TY_BASE_IMG}@sha256:%s " *)
+
+      - name: Export manifest digest
+        id: manifest-digest
+        env:
+          IMAGE: ${{ env.TY_BASE_IMG }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest="$(
+            docker buildx imagetools inspect \
+              "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}' \
+            | jq -r '.digest'
+          )"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.TY_BASE_IMG }}
+          subject-digest: ${{ steps.manifest-digest.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,9 @@ jobs:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
     permissions:
+      "attestations": "write"
       "contents": "read"
+      "id-token": "write"
       "packages": "write"
 
   # Build and package all the platform-agnostic(ish) things

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -64,7 +64,7 @@ publish-jobs = ["./publish-pypi"]
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./publish-docs", "./publish-mirror"]
 # Custom permissions for GitHub Jobs
-github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read" }, "publish-mirror" = { contents = "read" } }
+github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-mirror" = { contents = "read" } }
 # Whether to install an updater program
 install-updater = false
 # Path that installers should place binaries in


### PR DESCRIPTION
## Summary

Adds GitHub artifact attestations (SLSA provenance) for release artifacts and Docker images.

Users will be able to verify artifacts with:

```bash
# Release artifacts
gh attestation verify ty-x86_64-unknown-linux-gnu.tar.gz --repo astral-sh/ty

# Docker images
gh attestation verify oci://ghcr.io/astral-sh/ty:latest --repo astral-sh/ty
```

## Test Plan

Tested end-to-end release and attestation verification on my fork.

- Workflow run: https://github.com/shaanmajid/ty/actions/runs/22075911317
- Test release: https://github.com/shaanmajid/ty/releases/tag/0.0.17

Verify release artifacts:

```bash
gh release download 0.0.17 --repo shaanmajid/ty --pattern "ty-x86_64-unknown-linux-gnu.tar.gz" --dir /tmp
gh attestation verify /tmp/ty-x86_64-unknown-linux-gnu.tar.gz --repo shaanmajid/ty
```

Verify Docker images:

```bash
gh attestation verify oci://ghcr.io/shaanmajid/ty:0.0.17 --repo shaanmajid/ty
gh attestation verify oci://ghcr.io/shaanmajid/ty:alpine --repo shaanmajid/ty
gh attestation verify oci://ghcr.io/shaanmajid/ty:debian --repo shaanmajid/ty
```

## Notes

- `actions/attest-build-provenance` was preexisting in `dist-workspace.toml` but unused, so the upgrade across major versions is safe.
- This is effectively the same change set as astral-sh/ruff#23111, adapted for ty’s release workflows.