### PR TITLE
Fix renovate `actions/*-artifact` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],
       matchDatasources: ["gitea-tags", "github-tags"],
-      matchPackageNames: ["actions/.*-artifact"],
+      matchPackageNames: ["actions/upload-artifact", "actions/download-artifact"],
       description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {


### PR DESCRIPTION
The same as https://github.com/astral-sh/ruff/pull/23675/:

> The intention here is that this should be a regex match. But that evidently is not working (https://github.com/astral-sh/ruff/pull/23656 and https://github.com/astral-sh/ruff/pull/23655 were filed as separate PRs rather than one combined PR). Looking at the renovate docs, it's possible that we need to surround the string with `/` in order for it to be considered a regular expression -- i.e., `/actions/.*-artifact/` rather than `actions/.*-artifact`. But a regex here also just feels like it's overcomplicating things anyway -- the only ones we aare about are `upload-artifact` and `download-artifact`!

The same problem evidently exists on this repo too: see https://github.com/astral-sh/ty/pull/2933 and https://github.com/astral-sh/ty/pull/2934
