### PR TITLE
Add typeshed diff link to changelog during release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,7 +63,9 @@ if [ -n "$old_typeshed_commit" ] && [ -f "$typeshed_commit_file" ]; then
         # Match lines like "- Sync vendored typeshed stubs ([#NNNN](...))".
         # The pattern anchors on the trailing "))$" so it won't match lines
         # that already have a typeshed diff link appended.
-        sed -i "s|\(- Sync vendored typeshed stubs (.*)\))$|\1). ${typeshed_diff_link}|" CHANGELOG.md
+        # Use a temp file instead of `sed -i` for macOS/Linux portability.
+        sed "s|\(- Sync vendored typeshed stubs (.*)\))$|\1). ${typeshed_diff_link}|" CHANGELOG.md > CHANGELOG.md.tmp
+        mv CHANGELOG.md.tmp CHANGELOG.md
     fi
 fi
 


### PR DESCRIPTION
## Summary

Automatically generate and append a typeshed diff link to the changelog when the vendored typeshed source commit changes during a release.

The script now:
1. Captures the current typeshed source commit before updating Ruff
2. After running the release process, checks if the typeshed commit has changed
3. If it has changed and the changelog mentions a typeshed sync, appends a link to the GitHub diff showing what changed in typeshed

## Test Plan

No idea. I tried mucking around locally to fool the release script and/or rooster into thinking that we were doing a release that updated typeshed, but to no avail. I guess we just have to wait until we cut a release that includes a typeshed sync to see if this actually worked or not?