### PR TITLE
installers: Download releases from Astral's mirror first

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -65,6 +65,9 @@ install-updater = false
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
 # Whether source tarballs should include submodules
 recursive-tarball = true
+# Prefer simple hosting for downloads, falling back to GitHub releases
+hosting = ["simple", "github"]
+simple-download-url = "https://releases.astral.sh/github/ty/releases/download/{tag}"
 
 [dist.github-custom-runners]
 global = "depot-ubuntu-latest-4"


### PR DESCRIPTION
This is like https://github.com/astral-sh/ruff/pull/23617 but for ty.

## Test plan

```
❯ cargo dist build --tag 0.0.21 -a global
[...]

❯ sh target/distrib/ty-installer.sh -v
downloading ty 0.0.21 aarch64-apple-darwin
  from https://releases.astral.sh/github/ty/releases/download/0.0.21/ty-aarch64-apple-darwin.tar.gz
  to /var/folders/2p/zyzvnr4j5016wx4h0pdgbjb00000gn/T/tmp.94XQUlda6l/input.tar.gz
no checksums to verify
installing to /Users/zsol/.local/bin
  ty
everything's installed!
```
