### PR TITLE
✨ Quality: Missing PYTHON_VERSION environment variable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ty
+  PYTHON_VERSION: "3.13"
 
 jobs:
   python-package:


### PR DESCRIPTION
Closes #3088

## ✨ Code Quality

### Problem
The `python-package` job references `${{ env.PYTHON_VERSION }}` for the `setup-python` action's `python-version` input. However, `PYTHON_VERSION` is not defined anywhere in the workflow's or job's `env` block. This will evaluate to an empty string, which can cause `setup-python` to fail or silently fall back to the runner's default Python version, leading to inconsistent CI environments.


**Severity**: `medium`
**File**: `.github/workflows/ci.yaml`

### Solution
Define `PYTHON_VERSION` in the workflow's `env` block (e.g., `PYTHON_VERSION: "3.13"`), matching the configuration used in `.github/workflows/build-binaries.yml`.


### Changes
- `.github/workflows/ci.yaml` (modified)



## Summary



## Test Plan



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
