### PR TITLE
Use ty in Emacs with Eglot

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -124,6 +124,7 @@ Starting with version 2025.3, PyCharm users can enable native ty support in the 
 For more information, refer to [PyCharm documentation](https://www.jetbrains.com/help/pycharm/lsp-tools.html#ty).
 
 ## Emacs
+
 ty can be utilized as a language server via the built-in [Eglot](https://www.gnu.org/software/emacs/manual/html_node/eglot/index.html) client, which is part of Emacs since version 29.
 
 ```elisp


### PR DESCRIPTION
## Summary

Add instructions on how to use ty with Emacs to the editors documentation page.

## Test Plan

N/A
