### PR TITLE
docs: use content tabs

### DIFF
--- a/docs/exclusions.md
+++ b/docs/exclusions.md
@@ -4,21 +4,41 @@ ty automatically discovers all Python files in your project. You can customize w
 
 For example, with the following configuration, ty checks all Python files in the `src` and `tests` directories except those in the `src/generated` directory:
 
-```toml title="pyproject.toml"
-[tool.ty.src]
-include = ["src", "tests"]
-exclude = ["src/generated"]
-```
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.src]
+    include = ["src", "tests"]
+    exclude = ["src/generated"]
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [src]
+    include = ["src", "tests"]
+    exclude = ["src/generated"]
+    ```
 
 ## Default exclusions
 
 By default, ty excludes a [variety of commonly ignored directories](./reference/configuration.md#exclude_1). If you want to include one of these directories, you can do so by adding a negative `exclude` using a leading `!`:
 
-```toml title="pyproject.toml"
-[tool.ty.src]
-# Remove `build` from the excluded directories.
-exclude = ["!**/build/"]
-```
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.src]
+    # Remove `build` from the excluded directories.
+    exclude = ["!**/build/"]
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [src]
+    # Remove `build` from the excluded directories.
+    exclude = ["!**/build/"]
+    ```
 
 By default, ty ignores files listed in an `.ignore` or `.gitignore` file. To disable this functionality, set [`respect-ignore-files`](./reference/configuration.md#respect-ignore-files) to `false`.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -22,10 +22,19 @@ example-pkg
 
 then set [`environment.root`](./reference/configuration.md#root) in your `pyproject.toml` to `["./app"]`:
 
-```toml title="pyproject.toml"
-[tool.ty.environment]
-root = ["./app"]
-```
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.environment]
+    root = ["./app"]
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [environment]
+    root = ["./app"]
+    ```
 
 Note that a `./python` folder is automatically added to the project `root` if it exists,
 and is not itself a package (i.e. does not contain an `__init__.py` file or an

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -35,13 +35,25 @@ Rule levels can also be changed in the [`rules`](./reference/configuration.md#ru
 
 For example, the following is equivalent to the command above:
 
-```toml title="pyproject.toml"
-[tool.ty.rules]
-unused-ignore-comment = "warn"
-redundant-cast = "ignore"
-possibly-missing-attribute = "error"
-possibly-missing-import = "error"
-```
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.rules]
+    unused-ignore-comment = "warn"
+    redundant-cast = "ignore"
+    possibly-missing-attribute = "error"
+    possibly-missing-import = "error"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [rules]
+    unused-ignore-comment = "warn"
+    redundant-cast = "ignore"
+    possibly-missing-attribute = "error"
+    possibly-missing-import = "error"
+    ```
 
 You can also configure the level for all rules at once.
 
@@ -57,7 +69,16 @@ You can also configure this setting in the [`rules`](./reference/configuration.m
 
 For example, the following is equivalent to the command above:
 
-```toml title="pyproject.toml"
-[tool.ty.rules]
-all = "error"
-```
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.rules]
+    all = "error"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [rules]
+    all = "error"
+    ```


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Add content tabs in the documentation, showing both `pyproject.toml` and `ty.toml` variants. Same as in Ty's or Ruff’s documentation. Previously only `pyproject.toml` was shown, which might lead people to think that only this file is supported.

## Test Plan

<!-- How was it tested? -->

Manual testing building the docs locally.

