### PR TITLE
docs: Add typeHierarchy support in LSP feature reference

### DIFF
--- a/docs/features/language-server.md
+++ b/docs/features/language-server.md
@@ -145,7 +145,7 @@ within a few milliseconds, even on large projects.
 | [`textDocument/semanticTokens`][semantictokens]       | ✅ Supported     |                                                               |
 | [`textDocument/signatureHelp`][signaturehelp]         | ✅ Supported     |                                                               |
 | [`textDocument/typeDefinition`][typedefinition]       | ✅ Supported     |                                                               |
-| [`typeHierarchy/*`][typehierarchy]                    | ❌ Not supported | [#534]                                                        |
+| [`typeHierarchy/*`][typehierarchy]                    | ✅ Supported     |                                                               |
 | [`workspace/diagnostic`][workspacediagnostic]         | ✅ Supported     |                                                               |
 | [`workspace/symbol`][workspacesymbol]                 | ✅ Supported     |                                                               |
 | [`workspace/willRenameFiles`][willrenamefiles]        | ❌ Not supported | [#1560]                                                       |

--- a/docs/features/language-server.md
+++ b/docs/features/language-server.md
@@ -152,7 +152,6 @@ within a few milliseconds, even on large projects.
 
 [#1560]: https://github.com/astral-sh/ty/issues/1560
 [#1976]: https://github.com/astral-sh/ty/issues/1976
-[#534]: https://github.com/astral-sh/ty/issues/534
 [callhierarchy]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls
 [codeaction]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction
 [codelens]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add typeHierarchy support in the [LSP feature reference](https://docs.astral.sh/ty/features/language-server/#feature-reference). https://github.com/astral-sh/ty/issues/534 has been closed as fixed.