### PR TITLE
docs: Reference correct issue in FAQ regarding strict mode

### DIFF
--- a/docs/reference/typing-faq.md
+++ b/docs/reference/typing-faq.md
@@ -279,7 +279,7 @@ issue](https://github.com/astral-sh/ty/issues/1578).
 ## Does ty have a strict mode?
 
 Not yet. A stricter inference mode is tracked in
-[this issue](https://github.com/astral-sh/ty/issues/1240). In the meantime, you can consider using Ruff's
+[this issue](https://github.com/astral-sh/ty/issues/527). In the meantime, you can consider using Ruff's
 [`flake8-annotations` rules](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann) to enforce
 more explicit type annotations in your code.
 


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Reference the [correct issue](https://github.com/astral-sh/ty/issues/527) in [FAQ regarding strict mode](https://docs.astral.sh/ty/reference/typing-faq/#does-ty-have-a-strict-mode).

Fixes #3383.
