### PR TITLE
scripts/update_schemastore: use -C to allow re-running schema update on existing branch

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -82,7 +82,7 @@ def update_schemastore(
     ).strip()
     branch = f"update-ty-{current_sha}"
     check_call(
-        ["git", "switch", "-c", branch],
+        ["git", "switch", "-C", branch],
         cwd=schemastore_path,
     )
     check_call(


### PR DESCRIPTION
## Summary

`git switch -c <branch>` fails with a non-zero exit code if the branch already exists,
causing `check_call` to raise `CalledProcessError` and crash the script on any re-run
(e.g. after a network failure or interrupted push).

Since the branch name is derived from the current ty commit SHA, it stays the same
across retries on the same commit. The fix changes `-c` to `-C` (force-create), which
creates the branch if it doesn't exist or resets it to the current HEAD if it does —
making the script idempotent, consistent with the existing `--force` on `git push` and
the skip-clone guard for the schemastore directory.

## Test Plan

Run `scripts/update_schemastore.py` twice in a row on the same ty commit and confirm
the second invocation no longer crashes with a `CalledProcessError` on `git switch`.