### PR TITLE
scripts/update_schemastore: fix bytes leak in submodule mismatch message

### DIFF
--- a/scripts/test_update_schemastore.py
+++ b/scripts/test_update_schemastore.py
@@ -1,0 +1,87 @@
+"""Tests for update_schemastore.py."""
+
+from __future__ import annotations
+
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+# Make the scripts directory importable without installing anything.
+sys.path.insert(0, str(Path(__file__).parent))
+
+import update_schemastore  # noqa: E402
+
+
+def _run_main_with_mocked_git(
+    expected_sha: str | bytes,
+    actual_sha: str | bytes,
+) -> str:
+    """
+    Run the submodule-mismatch branch of main() with two fake SHAs and
+    capture what it prints.  Mocks out check_output so no real git is needed.
+    The user prompt is answered with 'n' (abort) to avoid any side effects.
+    """
+    call_count = 0
+
+    def fake_check_output(cmd, **kwargs):  # noqa: ANN001, ANN202
+        nonlocal call_count
+        call_count += 1
+        # First call  → ls-tree  → expected revision
+        # Second call → rev-parse → actual revision
+        if call_count == 1:
+            return expected_sha
+        return actual_sha
+
+    captured = StringIO()
+    with (
+        patch.object(update_schemastore, "check_output", side_effect=fake_check_output),
+        patch("builtins.input", return_value="n"),
+        patch("sys.stdout", captured),
+    ):
+        update_schemastore.main()
+
+    return captured.getvalue()
+
+
+class TestSubmoduleRevisionMessage:
+    """main() must print clean hex SHAs, not bytes repr, when revisions differ."""
+
+    EXPECTED_SHA = "deadbeef" * 5  # 40-char fake SHA
+    ACTUAL_SHA = "cafebabe" * 5    # 40-char fake SHA
+
+    def test_message_contains_actual_sha(self) -> None:
+        """The printed message includes the actual (checked-out) revision."""
+        output = _run_main_with_mocked_git(self.EXPECTED_SHA, self.ACTUAL_SHA)
+        assert self.ACTUAL_SHA in output
+
+    def test_message_contains_expected_sha(self) -> None:
+        """The printed message includes the expected (main-branch) revision."""
+        output = _run_main_with_mocked_git(self.EXPECTED_SHA, self.ACTUAL_SHA)
+        assert self.EXPECTED_SHA in output
+
+    def test_message_has_no_bytes_prefix(self) -> None:
+        """
+        Without text=True, check_output returns bytes and the f-string renders
+        them as  b'deadbeef...'.  This test fails on the original code and
+        passes after adding text=True to both check_output calls.
+        """
+        output = _run_main_with_mocked_git(self.EXPECTED_SHA, self.ACTUAL_SHA)
+        assert "b'" not in output, (
+            f"Message contains raw bytes repr — check_output calls are missing text=True.\n"
+            f"Actual output: {output!r}"
+        )
+
+    def test_message_still_fails_with_bytes_input(self) -> None:
+        """
+        Confirm the test is sensitive: if bytes are passed in (simulating the
+        pre-fix state), the no-bytes-prefix assertion would fire.
+        """
+        bytes_expected = self.EXPECTED_SHA.encode()
+        bytes_actual = self.ACTUAL_SHA.encode()
+        output = _run_main_with_mocked_git(bytes_expected, bytes_actual)
+        # With bytes the f-string embeds b'...' — assert that is detectable.
+        assert "b'" in output, (
+            "Expected bytes repr in output when bytes are passed in — "
+            "the test harness itself may be broken."
+        )

--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -157,10 +157,12 @@ def determine_git_protocol(argv: list[str] | None = None) -> GitProtocol:
 
 def main() -> None:
     expected_ruff_revision = check_output(
-        ["git", "ls-tree", "main", "--format", "%(objectname)", "ruff"], cwd=TY_ROOT
+        ["git", "ls-tree", "main", "--format", "%(objectname)", "ruff"], cwd=TY_ROOT,
+        text=True,
     ).strip()
     actual_ruff_revision = check_output(
-        ["git", "-C", "ruff", "rev-parse", "HEAD"], cwd=TY_ROOT
+        ["git", "-C", "ruff", "rev-parse", "HEAD"], cwd=TY_ROOT,
+        text=True,
     ).strip()
 
     if expected_ruff_revision != actual_ruff_revision:
@@ -182,7 +184,6 @@ def main() -> None:
             case command:
                 print(f"Invalid input '{command}', abort")
                 return
-
     schemastore_repos = determine_git_protocol().schemastore_repos()
     schemastore_existing = TY_ROOT / "schemastore"
     if schemastore_existing.is_dir():


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Both `check_output` calls in `main()` are missing `text=True`, so they return
`bytes` instead of `str`. The submodule mismatch message then prints raw byte
literals like `b'deadbeef...'` instead of clean hex SHAs. Adding `text=True`
to both calls fixes the output.

## Test Plan

Added `scripts/test_update_schemastore.py` which patches `check_output` to
return `bytes` and asserts no `b'...'` prefix appears in the printed message.
Fails on the original code, passes after the fix.