### PR TITLE
docs: add Flycheck note to Emacs editor integration

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -137,15 +137,7 @@ ty can be utilized as a language server via the built-in [Eglot](https://www.gnu
 
 If you prefer to view ty's diagnostics through [Flycheck](https://www.flycheck.org/), the
 [flycheck-eglot](https://github.com/flycheck/flycheck-eglot) package bridges Eglot's diagnostics
-to Flycheck:
-
-```elisp
-(use-package flycheck-eglot
-  :ensure t
-  :after (flycheck eglot)
-  :config
-  (global-flycheck-eglot-mode 1))
-```
+to Flycheck.
 
 ## Other editors
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -135,6 +135,18 @@ ty can be utilized as a language server via the built-in [Eglot](https://www.gnu
 (add-hook 'python-base-mode-hook 'eglot-ensure)
 ```
 
+If you prefer to view ty's diagnostics through [Flycheck](https://www.flycheck.org/), the
+[flycheck-eglot](https://github.com/flycheck/flycheck-eglot) package bridges Eglot's diagnostics
+to Flycheck:
+
+```elisp
+(use-package flycheck-eglot
+  :ensure t
+  :after (flycheck eglot)
+  :config
+  (global-flycheck-eglot-mode 1))
+```
+
 ## Other editors
 
 ty can be used with any editor that supports the [language server


### PR DESCRIPTION
## Summary

Adds a short note to the Emacs section of the editor integration docs explaining how Flycheck users can route ty's diagnostics through the [flycheck-eglot](https://github.com/flycheck/flycheck-eglot) bridge.

The current Eglot snippet (added in #3107) covers the simple case, but the original request in #2902 specifically asked about Flycheck-based setups. This adds the minimal additional snippet for that path without changing the existing recommended setup. Modeled on the multi-subsection layout used by Ruff's [Emacs docs](https://docs.astral.sh/ruff/editors/setup/#emacs).

Refs #2902.

## Test Plan

- `mdformat docs/editors.md --check` passes
- `markdownlint-cli@0.48.0 docs/editors.md` passes
- Verified `flycheck/flycheck-eglot` is the official upstream package