### PR TITLE
docs: set Eglot `:language-id` so ty works with `python-base-mode`

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -130,10 +130,15 @@ ty can be utilized as a language server via the built-in [Eglot](https://www.gnu
 ```elisp
 (with-eval-after-load 'eglot
   (add-to-list 'eglot-server-programs
-               '(python-base-mode . ("ty" "server"))))
+               '((python-base-mode :language-id "python") . ("ty" "server"))))
 
 (add-hook 'python-base-mode-hook 'eglot-ensure)
 ```
+
+The `:language-id "python"` entry ensures Eglot advertises the document as
+`python` rather than `python-base` when registering `python-base-mode`. The ty
+server only recognises the `python` language identifier and will silently skip
+documents that announce themselves under any other identifier.
 
 If you prefer to view ty's diagnostics through [Flycheck](https://www.flycheck.org/), the
 [flycheck-eglot](https://github.com/flycheck/flycheck-eglot) package bridges Eglot's diagnostics

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -135,11 +135,6 @@ ty can be utilized as a language server via the built-in [Eglot](https://www.gnu
 (add-hook 'python-base-mode-hook 'eglot-ensure)
 ```
 
-The `:language-id "python"` entry ensures Eglot advertises the document as
-`python` rather than `python-base` when registering `python-base-mode`. The ty
-server only recognises the `python` language identifier and will silently skip
-documents that announce themselves under any other identifier.
-
 If you prefer to view ty's diagnostics through [Flycheck](https://www.flycheck.org/), the
 [flycheck-eglot](https://github.com/flycheck/flycheck-eglot) package bridges Eglot's diagnostics
 to Flycheck.


### PR DESCRIPTION
## Summary

- Closes #2937.
- Adds `:language-id "python"` to the Eglot `eglot-server-programs` entry in the Emacs editor-integration docs so the recommended snippet works out of the box.
- Eglot derives the LSP `languageId` from the major-mode symbol, so the previous `python-base-mode` entry caused Eglot to advertise documents as `python-base`. The ty server only accepts the `python` language id ([`text_document.rs`](https://github.com/astral-sh/ruff/blob/main/crates/ty_server/src/document/text_document.rs)), so users were silently getting no diagnostics.
- Adds a short prose note explaining the constraint, so readers who copy the snippet (or adapt it for a different mode) understand why the entry is shaped this way. Fix matches the one suggested upstream in [eglot#1580](https://github.com/joaotavora/eglot/discussions/1580).

## Test plan

- [x] Visually proof the rendered Markdown
- [x] Verified the snippet shape against the eglot discussion accepted answer

