### PR TITLE
Release: Force usage of PyPI as the index

### DIFF
--- a/scripts/autogenerate_files.sh
+++ b/scripts/autogenerate_files.sh
@@ -13,7 +13,7 @@ project_root="$(dirname "$script_root")"
 cd "$project_root"
 
 echo "Updating lockfile..."
-uv lock
+uv lock --default-index https://pypi.org/simple
 
 echo "Copying reference documentation from Ruff..."
 cp ./ruff/crates/ty/docs/cli.md ./docs/reference/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -51,7 +51,7 @@ echo "Running rooster..."
 cd "$project_root"
 
 # Generate the changelog and bump versions
-uv run --isolated --only-group release \
+uv run --isolated --only-group release --default-index https://pypi.org/simple \
     rooster release "$@"
 
 # If the typeshed source commit changed and the changelog mentions a typeshed


### PR DESCRIPTION
## Summary

Make sure that the lockfile is not corrupted when uv's default config points to a company mirror. Tested by running `./scripts/release.sh` in an environment where the lockfile was previously corrupted.