### PR TITLE
Ensure the submodule is initialized in `release.sh`

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,6 +8,11 @@
 #
 set -eu
 
+if [ ! -e ruff/.git ]; then
+    echo "Initializing Ruff submodule..."
+    git submodule update --init --recursive ruff
+fi
+
 echo "Checking Ruff submodule status..."
 if git -C ruff diff --quiet; then
     echo "Ruff submodule is clean; continuing..."


### PR DESCRIPTION
## Summary

The release script failed on my new OpenAI machine because the Ruff submodule had not been initialized. This PR hardens the release script to ensure that the submodule is initialized.
