### PR TITLE
Bump version to 0.0.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.0.47
+
+Released on 2026-06-10.
+
+### Bug fixes
+
+- Avoid panicking on encountering a recursive NamedTuple that references a recursive NewType ([#25764](https://github.com/astral-sh/ruff/pull/25764))
+- Fix out-of-bound panic in notebooks involving suppression comments ([#25629](https://github.com/astral-sh/ruff/pull/25629))
+
+### Core type checking
+
+- Preserve overloads through callable protocol decorators ([#25806](https://github.com/astral-sh/ruff/pull/25806))
+- Sync vendored typeshed stubs ([#25779](https://github.com/astral-sh/ruff/pull/25779)). [Typeshed diff](https://github.com/python/typeshed/compare/4a47505dd891ac8a94ba7f4b578899c72727ce23...d3504ddc24c92b960a9661813efcdef10fad6d29)
+
+### Performance and memory-usage improvements
+
+- Avoid caching specialization-invariant known instances ([#25816](https://github.com/astral-sh/ruff/pull/25816))
+- Avoid resolving overload sets for ordinary functions ([#25817](https://github.com/astral-sh/ruff/pull/25817))
+- Store common definition inference results inline ([#25814](https://github.com/astral-sh/ruff/pull/25814))
+- Use `Box<SystemPath>` etc. in `Files` ([#25554](https://github.com/astral-sh/ruff/pull/25554))
+
+### Contributors
+
+- [@dhruvmanila](https://github.com/dhruvmanila)
+- [@MichaReiser](https://github.com/MichaReiser)
+- [@charliermarsh](https://github.com/charliermarsh)
+
 ## 0.0.46
 
 Released on 2026-06-08.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["cargo:./ruff"]
 packages = ["ty"]
-version = "0.0.46"
+version = "0.0.47"
 
 # Config for 'dist'
 [dist]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ ty includes a standalone installer.
     Request a specific version by including it in the URL:
 
     ```console
-    $ curl -LsSf https://astral.sh/ty/0.0.46/install.sh | sh
+    $ curl -LsSf https://astral.sh/ty/0.0.47/install.sh | sh
     ```
 
 === "Windows"
@@ -87,7 +87,7 @@ ty includes a standalone installer.
     Request a specific version by including it in the URL:
 
     ```pwsh-session
-    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/ty/0.0.46/install.ps1 | iex"
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/ty/0.0.47/install.ps1 | iex"
     ```
 
 !!! tip
@@ -163,7 +163,7 @@ COPY --from=ghcr.io/astral-sh/ty:latest /ty /bin/
 The following tags are available:
 
 - `ghcr.io/astral-sh/ty:latest`
-- `ghcr.io/astral-sh/ty:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/ty:0.0.46`
+- `ghcr.io/astral-sh/ty:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/ty:0.0.47`
 - `ghcr.io/astral-sh/ty:{major}.{minor}`, e.g., `ghcr.io/astral-sh/ty:0.0` (the latest patch
     version)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ty"
-version = "0.0.46"
+version = "0.0.47"
 requires-python = ">=3.8"
 dependencies = []
 description = "An extremely fast Python type checker, written in Rust."

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.46"
+version = "0.0.47"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

I accidentally bumped the ruff submodule commit in #3725, but this PR includes an additional submodule bump (and the changelog covers both submodule bumps).

