### PR TITLE
Automatically trigger new ty-pre-commit releases when we cut a release

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -1,0 +1,31 @@
+# Notify downstream repositories of a new release.
+#
+# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a post-announce
+# job within `cargo-dist`.
+name: "[ty] Notify dependents"
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  update-dependents:
+    name: Notify dependents
+    environment:
+      name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update pre-commit mirror"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.TY_PRE_COMMIT_PAT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'astral-sh',
+              repo: 'ty-pre-commit',
+              workflow_id: 'main.yml',
+              ref: 'main',
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,15 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  custom-notify-dependents:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/notify-dependents.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
   custom-publish-docs:
     needs:
       - plan

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -64,7 +64,7 @@ local-artifacts-jobs = ["./build-binaries", "./build-docker"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi"]
 # Post-announce jobs to run in CI
-post-announce-jobs = ["./publish-docs", "./publish-versions", "./publish-mirror"]
+post-announce-jobs = ["./notify-dependents", "./publish-docs", "./publish-versions", "./publish-mirror"]
 # Custom permissions for GitHub Jobs
 github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-mirror" = { contents = "read" } }
 # Whether to install an updater program


### PR DESCRIPTION
## Summary

This adds an additional step to our release workflow so that a new release auto-triggers a new ty-pre-commit release immediately. (Currently, the only trigger is a cron job over at ty-pre-commit that runs every four hours.) The new workflow works in exactly the same way as the existing workflow for Ruff.

In order for this to work, we will also need to add a `TY_PRE_COMMIT_PAT` secret, with Actions write access to `astral-sh/ty-pre-commit`, to the release environment. Ruff has the equivalent `RUFF_PRE_COMMIT_PAT`; without this secret, the new job will fail at dispatch time.