### PR TITLE
Pass PyPI version to ty-pre-commit when triggering a release in that repo

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: "Update pre-commit mirror"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ fromJson(inputs.plan).releases[0].app_version }}
         with:
           github-token: ${{ secrets.TY_PRE_COMMIT_PAT }}
           script: |
@@ -28,4 +30,7 @@ jobs:
               repo: 'ty-pre-commit',
               workflow_id: 'main.yml',
               ref: 'main',
+              inputs: {
+                version: process.env.VERSION,
+              },
             })


### PR DESCRIPTION
## Summary

See https://github.com/astral-sh/ty-pre-commit/pull/12. That PR would have to be merged before merging this one.
