### PR TITLE
Removes an irrelevant line from the `unsupported-bool-conversion` reference that instead triggers `unsupported-operator`

### DIFF
--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -4050,7 +4050,6 @@ if b1:  # exception raised here
 
 b1 and b2  # exception raised here
 not b1  # exception raised here
-b1 < b2 < b1  # exception raised here
 ```
 
 ## `unsupported-dynamic-base`


### PR DESCRIPTION
## Summary

Closes #3789.

## Test Plan

No tests are needed.
