### PR TITLE
Add PGO to native ty release builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -70,7 +70,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-15-intel
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -225,7 +225,7 @@ jobs:
           PGO_TARGET_DIR="$(cygpath -u "${RUNNER_TEMP}")/ty-pgo" \
           scripts/build_ty_pgo.sh
         env:
-          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@8f72ceebb2339aa0d08f8d54bf206c4418a08dea
+          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@b82a3e8098d0535175d15f9024c9d5bd720bad8d
           PGO_TRAIN_ONLY: 1
       - name: "Prep README.md"
         run: python scripts/transform_readme.py

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -225,7 +225,7 @@ jobs:
           PGO_TARGET_DIR="$(cygpath -u "${RUNNER_TEMP}")/ty-pgo" \
           scripts/build_ty_pgo.sh
         env:
-          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@9ed6b0f76118ab3abf3964395d311eeb8b979b4b
+          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@8f72ceebb2339aa0d08f8d54bf206c4418a08dea
           PGO_TRAIN_ONLY: 1
       - name: "Prep README.md"
         run: python scripts/transform_readme.py

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,6 +18,7 @@ on:
       - pyproject.toml
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
+      - scripts/build_ty_pgo.sh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,7 +70,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-15
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -122,6 +123,20 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: arm64
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          version: "0.11.19"
+      - name: Install llvm-profdata
+        run: rustup component add llvm-tools-preview
+      - name: Check native target
+        run: |
+          test "$(rustc -vV | sed -n 's/^host: //p' | tr -d '\r')" = "aarch64-apple-darwin"
+      - name: Train PGO ty
+        run: scripts/build_ty_pgo.sh
+        env:
+          PGO_TRAIN_ONLY: 1
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels - aarch64"
@@ -130,6 +145,8 @@ jobs:
           maturin-version: v1.13.3
           target: aarch64
           args: --release --locked --out dist --compatibility pypi
+        env:
+          RUSTFLAGS: -Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata -Cllvm-args=-pgo-warn-missing-function
       - name: "Test wheel - aarch64"
         run: |
           pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
@@ -234,6 +251,24 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: Install the latest version of uv
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          version: "0.11.19"
+      - name: Install llvm-profdata
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        run: rustup component add llvm-tools-preview
+      - name: Check native target
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        run: |
+          test "$(rustc -vV | sed -n 's/^host: //p' | tr -d '\r')" = "x86_64-unknown-linux-gnu"
+      - name: Train PGO ty
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        run: scripts/build_ty_pgo.sh
+        env:
+          PGO_TRAIN_ONLY: 1
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels"
@@ -242,7 +277,10 @@ jobs:
           maturin-version: v1.13.3
           target: ${{ matrix.target }}
           manylinux: 2_17
+          docker-options: ${{ startsWith(matrix.target, 'x86_64') && '-e RUSTFLAGS' || '' }}
           args: --release --locked --out dist --compatibility pypi
+        env:
+          RUSTFLAGS: ${{ startsWith(matrix.target, 'x86_64') && format('-Cprofile-use={0}/ruff/target/ty-pgo/ty.profdata -Cllvm-args=-pgo-warn-missing-function', github.workspace) || '' }}
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -276,18 +314,82 @@ jobs:
             *.tar.gz
             *.sha256
 
+  linux-aarch64:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: arm64
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          version: "0.11.19"
+      - name: Install llvm-profdata
+        run: rustup component add llvm-tools-preview
+      - name: Check native target
+        run: |
+          test "$(rustc -vV | sed -n 's/^host: //p' | tr -d '\r')" = "aarch64-unknown-linux-gnu"
+      - name: Train PGO ty
+        run: scripts/build_ty_pgo.sh
+        env:
+          PGO_TRAIN_ONLY: 1
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: v1.13.3
+          target: aarch64-unknown-linux-gnu
+          manylinux: 2_17
+          docker-options: -e JEMALLOC_SYS_WITH_LG_PAGE=16 -e RUSTFLAGS
+          args: --release --locked --out dist --compatibility pypi
+        env:
+          RUSTFLAGS: -Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata -Cllvm-args=-pgo-warn-missing-function
+      - name: "Test wheel"
+        run: |
+          pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
+          "${MODULE_NAME}" version
+          "${MODULE_NAME}" --help
+          python -m "${MODULE_NAME}" --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-aarch64-unknown-linux-gnu
+          path: dist
+      - name: "Archive binary"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TARGET=aarch64-unknown-linux-gnu
+          ARCHIVE_NAME=ty-$TARGET
+          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+
+          mkdir -p $ARCHIVE_NAME
+          cp ruff/target/$TARGET/release/ty $ARCHIVE_NAME/ty
+          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: artifacts-aarch64-unknown-linux-gnu
+          path: |
+            *.tar.gz
+            *.sha256
+
   linux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         platform:
-          - target: aarch64-unknown-linux-gnu
-            arch: aarch64
-            manylinux: 2_17
-            # see https://github.com/astral-sh/ruff/issues/3791
-            # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
-            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
             manylinux: 2_17

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -196,6 +196,37 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
+      - name: Install the latest version of uv
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          version: "0.11.19"
+      - name: Install llvm-profdata
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        run: rustup component add llvm-tools-preview
+      - name: Check native target
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        shell: bash
+        run: |
+          test "$(rustc -vV | sed -n 's/^host: //p' | tr -d '\r')" = "x86_64-pc-windows-msvc"
+      - name: Configure Git for ecosystem corpus
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        shell: bash
+        run: git config --system core.longpaths true
+      - name: Train PGO ty
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        shell: bash
+        run: |
+          temp_dir="$(cygpath -u "${RUNNER_TEMP}")/ty-pgo-tmp"
+          mkdir -p "${temp_dir}"
+          TMP="$(cygpath -w "${temp_dir}")" \
+          TEMP="$(cygpath -w "${temp_dir}")" \
+          PGO_TARGET_DIR="$(cygpath -u "${RUNNER_TEMP}")/ty-pgo" \
+          scripts/build_ty_pgo.sh
+        env:
+          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@3e7e4f85266d060156a7c511a921c554de33f35f
+          PGO_TRAIN_ONLY: 1
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels"
@@ -207,6 +238,7 @@ jobs:
         env:
           # aarch64 build fails, see https://github.com/PyO3/maturin/issues/2110
           XWIN_VERSION: 16
+          RUSTFLAGS: ${{ startsWith(matrix.platform.target, 'x86_64') && format('-Cprofile-use={0}/ty-pgo/ty.profdata -Cllvm-args=-pgo-warn-missing-function', runner.temp) || '' }}
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,6 +18,7 @@ on:
       - pyproject.toml
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
+      - .github/ty-ecosystem.toml
       - scripts/build_ty_pgo.sh
 
 concurrency:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -225,7 +225,7 @@ jobs:
           PGO_TARGET_DIR="$(cygpath -u "${RUNNER_TEMP}")/ty-pgo" \
           scripts/build_ty_pgo.sh
         env:
-          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@3e7e4f85266d060156a7c511a921c554de33f35f
+          ECOSYSTEM_ANALYZER_SOURCE: git+https://github.com/MichaReiser/ecosystem-analyzer@9ed6b0f76118ab3abf3964395d311eeb8b979b4b
           PGO_TRAIN_ONLY: 1
       - name: "Prep README.md"
         run: python scripts/transform_readme.py

--- a/scripts/benchmark_ty_pgo.sh
+++ b/scripts/benchmark_ty_pgo.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ECOSYSTEM_ANALYZER_COMMIT="${ECOSYSTEM_ANALYZER_COMMIT:-7e3a45ca84ad4a30ba90cb27af0b568f37608e84}"
+RUFF_DIR="${RUFF_DIR:-ruff}"
+EXCLUDE_NEWER="${EXCLUDE_NEWER:-$(git -C "${RUFF_DIR}" show --no-ext-diff --format=%cI --no-patch HEAD)}"
+TY_MAX_PARALLELISM="${TY_MAX_PARALLELISM:-8}"
+BENCHMARK_DIR="${BENCHMARK_DIR:-${RUFF_DIR}/target/ty-pgo-benchmark}"
+case "${RUFF_DIR}" in
+  /*) ruff_dir="${RUFF_DIR}" ;;
+  *) ruff_dir="$(pwd)/${RUFF_DIR}" ;;
+esac
+case "${BENCHMARK_DIR}" in
+  /*) benchmark_dir="${BENCHMARK_DIR}" ;;
+  *) benchmark_dir="$(pwd)/${BENCHMARK_DIR}" ;;
+esac
+RELEASE_TARGET_DIR="${benchmark_dir}/release"
+PGO_TARGET_DIR="${benchmark_dir}/pgo"
+RELEASE_TY="${RELEASE_TARGET_DIR}/release/ty"
+PGO_TY="${PGO_TARGET_DIR}/release/ty"
+ECOSYSTEM_DIR="${benchmark_dir}/ecosystem"
+ECOSYSTEM_CONFIG_DIR="${ECOSYSTEM_DIR}/config"
+ECOSYSTEM_CACHE_DIR="${ECOSYSTEM_DIR}/cache"
+
+echo "Building release ty"
+(
+  cd "${ruff_dir}"
+  CARGO_TARGET_DIR="${RELEASE_TARGET_DIR}" cargo build --locked --package ty --release
+)
+
+RUFF_DIR="${ruff_dir}" \
+PGO_TARGET_DIR="${PGO_TARGET_DIR}" \
+PGO_OUTPUT="${PGO_TY}" \
+EXCLUDE_NEWER="${EXCLUDE_NEWER}" \
+ECOSYSTEM_ANALYZER_COMMIT="${ECOSYSTEM_ANALYZER_COMMIT}" \
+scripts/build_ty_pgo.sh
+
+echo "Comparing release and PGO release on the ecosystem analyzer corpus"
+mkdir -p "${ECOSYSTEM_CONFIG_DIR}/ty"
+cp "${ruff_dir}/.github/ty-ecosystem.toml" "${ECOSYSTEM_CONFIG_DIR}/ty/ty.toml"
+(
+  cd "${ruff_dir}"
+  TY_MAX_PARALLELISM="${TY_MAX_PARALLELISM}" UV_EXCLUDE_NEWER="${EXCLUDE_NEWER}" XDG_CACHE_HOME="${ECOSYSTEM_CACHE_DIR}" XDG_CONFIG_HOME="${ECOSYSTEM_CONFIG_DIR}" uvx \
+    --from "git+https://github.com/astral-sh/ecosystem-analyzer@${ECOSYSTEM_ANALYZER_COMMIT}" \
+    ecosystem-analyzer \
+    --flaky-runs 1 \
+    diff \
+    --old HEAD \
+    --new HEAD \
+    --ty-binary-old "${RELEASE_TY}" \
+    --ty-binary-new "${PGO_TY}" \
+    --output-old "${ECOSYSTEM_DIR}/release.json" \
+    --output-new "${ECOSYSTEM_DIR}/pgo.json"
+)
+
+uvx \
+  --from "git+https://github.com/astral-sh/ecosystem-analyzer@${ECOSYSTEM_ANALYZER_COMMIT}" \
+  ecosystem-analyzer \
+  generate-timing-diff \
+  "${ECOSYSTEM_DIR}/release.json" \
+  "${ECOSYSTEM_DIR}/pgo.json" \
+  --old-name release \
+  --new-name pgo-release \
+  --output-html "${ECOSYSTEM_DIR}/timing.html"
+
+echo "Ecosystem timing report: ${ECOSYSTEM_DIR}/timing.html"

--- a/scripts/benchmark_ty_pgo_instructions.sh
+++ b/scripts/benchmark_ty_pgo_instructions.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ECOSYSTEM_ANALYZER_COMMIT="${ECOSYSTEM_ANALYZER_COMMIT:-7e3a45ca84ad4a30ba90cb27af0b568f37608e84}"
+BENCHMARK_DIR="${BENCHMARK_DIR:-ruff/target/ty-pgo-benchmark}"
+RELEASE_TY="${BENCHMARK_DIR}/release/release/ty"
+PGO_TY="${BENCHMARK_DIR}/pgo/release/ty"
+
+if [[ ! -x "${RELEASE_TY}" || ! -x "${PGO_TY}" ]]; then
+  echo "Build release ty and run scripts/build_ty_pgo.sh before comparing instructions." >&2
+  exit 1
+fi
+
+env -u UV_EXCLUDE_NEWER UV_NO_CONFIG=1 uv run \
+  --no-project \
+  --python 3.14 \
+  --with "git+https://github.com/astral-sh/ecosystem-analyzer@${ECOSYSTEM_ANALYZER_COMMIT}" \
+  python scripts/compare_ty_pgo_instructions.py \
+  --release-ty "${RELEASE_TY}" \
+  --pgo-ty "${PGO_TY}" \
+  "$@"

--- a/scripts/build_ty_pgo.sh
+++ b/scripts/build_ty_pgo.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ECOSYSTEM_ANALYZER_COMMIT="${ECOSYSTEM_ANALYZER_COMMIT:-7e3a45ca84ad4a30ba90cb27af0b568f37608e84}"
+ECOSYSTEM_ANALYZER_SOURCE="${ECOSYSTEM_ANALYZER_SOURCE:-git+https://github.com/astral-sh/ecosystem-analyzer@${ECOSYSTEM_ANALYZER_COMMIT}}"
 RUFF_DIR="${RUFF_DIR:-ruff}"
 EXCLUDE_NEWER="${EXCLUDE_NEWER:-$(git -C "${RUFF_DIR}" show --no-ext-diff --format=%cI --no-patch HEAD)}"
 PGO_TARGET_DIR="${PGO_TARGET_DIR:-${RUFF_DIR}/target/ty-pgo}"
@@ -11,14 +12,19 @@ TY_MAX_PARALLELISM="${TY_MAX_PARALLELISM:-8}"
 CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
 
 case "$(uname -s)" in
-  Darwin | Linux) ;;
+  Darwin | Linux)
+    pgo_binary="ty"
+    ;;
+  CYGWIN* | MINGW* | MSYS*)
+    pgo_binary="ty.exe"
+    ;;
   *)
-    echo "scripts/build_ty_pgo.sh only supports host-native Darwin and Linux builds." >&2
+    echo "scripts/build_ty_pgo.sh only supports host-native Darwin, Linux, and Windows builds." >&2
     exit 1
   ;;
 esac
 
-PGO_OUTPUT="${PGO_OUTPUT:-${PGO_TARGET_DIR}/release/ty}"
+PGO_OUTPUT="${PGO_OUTPUT:-${PGO_TARGET_DIR}/release/${pgo_binary}}"
 
 find_llvm_profdata() {
   if [[ -n "${LLVM_PROFDATA:-}" ]]; then
@@ -37,6 +43,10 @@ find_llvm_profdata() {
   rustc_llvm_profdata="$(rustc --print sysroot)/lib/rustlib/${rustc_host}/bin/llvm-profdata"
   if [[ -x "${rustc_llvm_profdata}" ]]; then
     echo "${rustc_llvm_profdata}"
+    return
+  fi
+  if [[ -x "${rustc_llvm_profdata}.exe" ]]; then
+    echo "${rustc_llvm_profdata}.exe"
     return
   fi
 
@@ -88,7 +98,7 @@ echo "Building and training instrumented ty with the ecosystem analyzer corpus"
   XDG_CACHE_HOME="${cache_dir}" \
   XDG_CONFIG_HOME="${config_dir}" \
   uvx \
-    --from "git+https://github.com/astral-sh/ecosystem-analyzer@${ECOSYSTEM_ANALYZER_COMMIT}" \
+    --from "${ECOSYSTEM_ANALYZER_SOURCE}" \
     ecosystem-analyzer \
     --repository . \
     --target "${instrumented_target_dir}" \

--- a/scripts/build_ty_pgo.sh
+++ b/scripts/build_ty_pgo.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ECOSYSTEM_ANALYZER_COMMIT="${ECOSYSTEM_ANALYZER_COMMIT:-7e3a45ca84ad4a30ba90cb27af0b568f37608e84}"
+RUFF_DIR="${RUFF_DIR:-ruff}"
+EXCLUDE_NEWER="${EXCLUDE_NEWER:-$(git -C "${RUFF_DIR}" show --no-ext-diff --format=%cI --no-patch HEAD)}"
+PGO_TARGET_DIR="${PGO_TARGET_DIR:-${RUFF_DIR}/target/ty-pgo}"
+PGO_OUTPUT="${PGO_OUTPUT:-}"
+PGO_TRAIN_ONLY="${PGO_TRAIN_ONLY:-0}"
+TY_MAX_PARALLELISM="${TY_MAX_PARALLELISM:-8}"
+CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+
+case "$(uname -s)" in
+  Darwin | Linux) ;;
+  *)
+    echo "scripts/build_ty_pgo.sh only supports host-native Darwin and Linux builds." >&2
+    exit 1
+  ;;
+esac
+
+PGO_OUTPUT="${PGO_OUTPUT:-${PGO_TARGET_DIR}/release/ty}"
+
+find_llvm_profdata() {
+  if [[ -n "${LLVM_PROFDATA:-}" ]]; then
+    echo "${LLVM_PROFDATA}"
+    return
+  fi
+
+  if command -v llvm-profdata >/dev/null 2>&1; then
+    command -v llvm-profdata
+    return
+  fi
+
+  local rustc_host
+  rustc_host="$(rustc -vV | sed -n 's/^host: //p')"
+  local rustc_llvm_profdata
+  rustc_llvm_profdata="$(rustc --print sysroot)/lib/rustlib/${rustc_host}/bin/llvm-profdata"
+  if [[ -x "${rustc_llvm_profdata}" ]]; then
+    echo "${rustc_llvm_profdata}"
+    return
+  fi
+
+  echo "llvm-profdata was not found. Install llvm-tools-preview or set LLVM_PROFDATA." >&2
+  exit 1
+}
+
+append_rustflags() {
+  local pgo_rustflags="$1"
+  if [[ -n "${RUSTFLAGS:-}" ]]; then
+    echo "${RUSTFLAGS} ${pgo_rustflags}"
+  else
+    echo "${pgo_rustflags}"
+  fi
+}
+
+case "${RUFF_DIR}" in
+  /*) ruff_dir="${RUFF_DIR}" ;;
+  *) ruff_dir="$(pwd)/${RUFF_DIR}" ;;
+esac
+case "${PGO_TARGET_DIR}" in
+  /*) pgo_target_dir="${PGO_TARGET_DIR}" ;;
+  *) pgo_target_dir="$(pwd)/${PGO_TARGET_DIR}" ;;
+esac
+case "${PGO_OUTPUT}" in
+  /*) pgo_output="${PGO_OUTPUT}" ;;
+  *) pgo_output="$(pwd)/${PGO_OUTPUT}" ;;
+esac
+
+llvm_profdata="$(find_llvm_profdata)"
+instrumented_target_dir="${pgo_target_dir}/instrumented"
+profile_dir="${pgo_target_dir}/profiles"
+merged_profile="${pgo_target_dir}/ty.profdata"
+diagnostics="${pgo_target_dir}/ecosystem-diagnostics.json"
+config_dir="${pgo_target_dir}/config"
+cache_dir="${pgo_target_dir}/cache"
+
+rm -rf "${profile_dir}"
+mkdir -p "${profile_dir}" "${config_dir}/ty"
+cp "${ruff_dir}/.github/ty-ecosystem.toml" "${config_dir}/ty/ty.toml"
+
+echo "Building and training instrumented ty with the ecosystem analyzer corpus"
+(
+  cd "${ruff_dir}"
+  RUSTFLAGS="$(append_rustflags "-Cprofile-generate=${profile_dir} -Cllvm-args=-vp-counters-per-site=16")" \
+  CARGO_INCREMENTAL="${CARGO_INCREMENTAL}" \
+  TY_MAX_PARALLELISM="${TY_MAX_PARALLELISM}" \
+  UV_EXCLUDE_NEWER="${EXCLUDE_NEWER}" \
+  XDG_CACHE_HOME="${cache_dir}" \
+  XDG_CONFIG_HOME="${config_dir}" \
+  uvx \
+    --from "git+https://github.com/astral-sh/ecosystem-analyzer@${ECOSYSTEM_ANALYZER_COMMIT}" \
+    ecosystem-analyzer \
+    --repository . \
+    --target "${instrumented_target_dir}" \
+    analyze \
+    --commit HEAD \
+    --profile release \
+    --output "${diagnostics}"
+)
+
+"${llvm_profdata}" merge --output="${merged_profile}" "${profile_dir}"
+echo "PGO profile: ${merged_profile}"
+
+if [[ "${PGO_TRAIN_ONLY}" == "1" ]]; then
+  exit 0
+fi
+
+echo "Building PGO ty"
+(
+  cd "${ruff_dir}"
+  RUSTFLAGS="$(append_rustflags "-Cprofile-use=${merged_profile} -Cllvm-args=-pgo-warn-missing-function")" \
+  CARGO_INCREMENTAL="${CARGO_INCREMENTAL}" \
+  CARGO_TARGET_DIR="${pgo_target_dir}" \
+  cargo build --locked --package ty --release
+)
+
+test -x "${pgo_output}"
+echo "PGO ty binary: ${pgo_output}"

--- a/scripts/compare_ty_pgo_instructions.py
+++ b/scripts/compare_ty_pgo_instructions.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+from ecosystem_analyzer.installed_project import InstalledProject
+from ecosystem_analyzer.manager import Manager, get_ecosystem_projects
+
+RUFF_DIR = Path("ruff")
+TY_MAX_PARALLELISM = "8"
+EXPECTED_TY_EXIT_CODES = {0, 1}
+
+
+@dataclass(frozen=True)
+class Comparison:
+    name: str
+    release: int
+    pgo_release: int
+
+    @property
+    def delta_percent(self) -> float:
+        return (self.pgo_release - self.release) / self.release * 100
+
+    @property
+    def speedup(self) -> float:
+        return self.release / self.pgo_release
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare release and PGO ty retired instructions with eight ty threads."
+    )
+    parser.add_argument(
+        "--release-ty",
+        type=Path,
+        default=Path("ruff/target/ty-pgo-benchmark/release/release/ty"),
+    )
+    parser.add_argument(
+        "--pgo-ty",
+        type=Path,
+        default=Path("ruff/target/ty-pgo-benchmark/pgo/release/ty"),
+    )
+    parser.add_argument(
+        "--perf",
+        type=Path,
+        default=Path("perf"),
+        help="Path to a perf binary with access to instructions:u.",
+    )
+    parser.add_argument(
+        "--exclude-newer",
+        default=subprocess.check_output(
+            [
+                "git",
+                "-C",
+                RUFF_DIR.as_posix(),
+                "show",
+                "--no-ext-diff",
+                "--format=%cI",
+                "--no-patch",
+                "HEAD",
+            ],
+            text=True,
+        ).strip(),
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=1,
+        help="Instruction counts are stable; increase only to take medians.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ruff/target/ty-pgo-benchmark/instructions.json"),
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    if args.runs < 1:
+        parser.error("--runs must be at least one")
+
+    release_ty = args.release_ty.resolve()
+    pgo_ty = args.pgo_ty.resolve()
+    for binary in (release_ty, pgo_ty):
+        if not binary.is_file():
+            parser.error(f"ty binary does not exist: {binary}")
+
+    perf = resolve_perf(args.perf)
+    output = args.output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    config_home = output.parent / "config"
+    cache_home = output.parent / "cache"
+    (config_home / "ty").mkdir(parents=True, exist_ok=True)
+    (config_home / "ty" / "ty.toml").write_text(
+        (RUFF_DIR / ".github/ty-ecosystem.toml").read_text()
+    )
+
+    env = os.environ.copy()
+    env["TY_MAX_PARALLELISM"] = TY_MAX_PARALLELISM
+    env["UV_EXCLUDE_NEWER"] = args.exclude_newer
+    env["XDG_CACHE_HOME"] = cache_home.as_posix()
+    env["XDG_CONFIG_HOME"] = config_home.as_posix()
+    check_perf(perf, env)
+
+    temporary_environment = {
+        name: env[name]
+        for name in ("UV_EXCLUDE_NEWER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME")
+    }
+    previous_environment = {
+        name: os.environ.get(name) for name in temporary_environment
+    }
+    os.environ.update(temporary_environment)
+    try:
+        ecosystem = compare_ecosystem(
+            release_ty=release_ty,
+            pgo_ty=pgo_ty,
+            perf=perf,
+            runs=args.runs,
+            env=env,
+        )
+    finally:
+        for name, value in previous_environment.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    payload = {
+        "ty_max_parallelism": int(TY_MAX_PARALLELISM),
+        "ecosystem": comparison_payload(ecosystem),
+    }
+    output.write_text(json.dumps(payload, indent=2) + "\n")
+    print_summary("ecosystem", ecosystem)
+    print(f"Wrote {output}")
+
+
+def resolve_perf(perf: Path) -> Path:
+    if perf.is_file():
+        return perf.resolve()
+
+    resolved = shutil.which(perf.as_posix())
+    if resolved is None:
+        raise SystemExit(f"perf binary not found: {perf}")
+    return Path(resolved).resolve()
+
+
+def check_perf(perf: Path, env: dict[str, str]) -> None:
+    try:
+        measure_instructions(command=["true"], cwd=Path.cwd(), perf=perf, env=env)
+    except RuntimeError as error:
+        raise SystemExit(f"perf cannot count instructions:u:\n{error}") from error
+
+
+def compare_ecosystem(
+    *,
+    release_ty: Path,
+    pgo_ty: Path,
+    perf: Path,
+    runs: int,
+    env: dict[str, str],
+) -> list[Comparison]:
+    projects = get_ecosystem_projects()
+    manager = Manager(
+        ty_repo=None,
+        target_dir=None,
+        project_names=sorted(projects),
+        profile="release",
+        flaky_runs=1,
+        exclude_newer=None,
+        ecosystem_projects=projects,
+    )
+    manager._ensure_installed()
+    installed_projects = sorted(
+        manager._installed_projects, key=lambda project: project.name
+    )
+
+    return [
+        compare_command(
+            name=project.name,
+            release_command=ecosystem_command(release_ty, project),
+            pgo_command=ecosystem_command(pgo_ty, project),
+            cwd=project.root_directory,
+            perf=perf,
+            runs=runs,
+            env=env,
+        )
+        for project in installed_projects
+    ]
+
+
+def ecosystem_command(binary: Path, project: InstalledProject) -> list[str]:
+    standard_flags = [
+        "--output-format=concise",
+        "--python",
+        str(project.venv_path),
+    ]
+    if project.ty_cmd:
+        command = []
+        for part in shlex.split(project.ty_cmd):
+            if part == "{ty}":
+                command.append(binary.as_posix())
+            elif part == "{paths}":
+                command.extend(project.paths)
+            else:
+                command.append(part)
+        command.extend(standard_flags)
+        return command
+
+    return [binary.as_posix(), "check", *standard_flags, *project.paths]
+
+
+def compare_command(
+    *,
+    name: str,
+    release_command: list[str],
+    pgo_command: list[str],
+    cwd: Path,
+    perf: Path,
+    runs: int,
+    env: dict[str, str],
+) -> Comparison:
+    logging.info("Counting instructions for %s", name)
+    release = measure_median(
+        command=release_command, cwd=cwd, perf=perf, runs=runs, env=env
+    )
+    pgo_release = measure_median(
+        command=pgo_command, cwd=cwd, perf=perf, runs=runs, env=env
+    )
+    return Comparison(name=name, release=release, pgo_release=pgo_release)
+
+
+def measure_median(
+    *, command: list[str], cwd: Path, perf: Path, runs: int, env: dict[str, str]
+) -> int:
+    return int(
+        median(
+            measure_instructions(command=command, cwd=cwd, perf=perf, env=env)
+            for _ in range(runs)
+        )
+    )
+
+
+def measure_instructions(
+    *, command: list[str], cwd: Path, perf: Path, env: dict[str, str]
+) -> int:
+    with tempfile.NamedTemporaryFile() as perf_output:
+        result = subprocess.run(
+            [
+                perf.as_posix(),
+                "stat",
+                "--no-big-num",
+                "-x",
+                "\t",
+                "-e",
+                "instructions:u",
+                "--output",
+                perf_output.name,
+                "--",
+                *command,
+            ],
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        if result.returncode not in EXPECTED_TY_EXIT_CODES:
+            raise RuntimeError(
+                f"perf failed for {shlex.join(command)} with exit code {result.returncode}:\n"
+                f"{result.stderr}"
+            )
+
+        for line in Path(perf_output.name).read_text().splitlines():
+            fields = line.split("\t")
+            if len(fields) >= 3 and fields[2] == "instructions:u":
+                return int(fields[0])
+
+    raise RuntimeError(f"perf did not report instructions for {shlex.join(command)}")
+
+
+def comparison_payload(comparisons: list[Comparison]) -> dict[str, Any]:
+    release = sum(comparison.release for comparison in comparisons)
+    pgo_release = sum(comparison.pgo_release for comparison in comparisons)
+    return {
+        "summary": {
+            "projects": len(comparisons),
+            "release": release,
+            "pgo_release": pgo_release,
+            "delta_percent": (pgo_release - release) / release * 100,
+            "speedup": release / pgo_release,
+        },
+        "projects": [
+            asdict(comparison)
+            | {
+                "delta_percent": comparison.delta_percent,
+                "speedup": comparison.speedup,
+            }
+            for comparison in comparisons
+        ],
+    }
+
+
+def print_summary(name: str, comparisons: list[Comparison]) -> None:
+    summary = comparison_payload(comparisons)["summary"]
+    print(
+        f"{name}: release={summary['release']:,} instructions, "
+        f"pgo-release={summary['pgo_release']:,} instructions, "
+        f"delta={summary['delta_percent']:+.2f}%, "
+        f"speedup={summary['speedup']:.3f}x"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Train Darwin and Linux GNU release wheels on the ecosystem analyzer corpus before the final maturin build, then feed the merged profile into the shipping build.
Add local helpers for reproducing PGO builds and corpus comparisons.
Testing: Ran focused hooks, a clean train-only PGO corpus run, and Build binaries CI.