### PR TITLE
Document Python version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ ty uses `0.0.x` versioning. ty does not yet have a stable API; breaking changes,
 to diagnostics, may occur between any two versions. See the [type system support](https://github.com/astral-sh/ty/issues/1889)
 tracking issue for a detailed overview of currently supported features.
 
+ty officially supports type checking code that targets Python 3.10 and later. Earlier versions
+(Python 3.7 through 3.9) can still be selected, but may result in false negatives or false
+positives due to a lack of bundled standard library stubs.
+
 ## FAQ
 
 <!-- We intentionally use smaller headings for the FAQ items -->

--- a/docs/python-version.md
+++ b/docs/python-version.md
@@ -40,3 +40,10 @@ ty will fall back to the latest stable Python version supported by ty (currently
 The Python version may also be explicitly specified using the
 [`python-version`](./reference/configuration.md#python-version) setting or the
 [`--python-version`](./reference/cli.md#ty-check--python-version) flag.
+
+ty officially supports type checking code that targets Python 3.10 and later, though earlier
+versions (Python 3.7 through 3.9) can still be selected as targets. When analyzing code under
+`--python-version=3.7` or similar, ty will continue to check version-dependent syntax, perform
+narrowing based on `sys.version_info`, and more, but may produce false positives or false
+negatives for standard-library APIs as its bundled stubs do not fully describe those Python
+versions.


### PR DESCRIPTION
## Summary

Document that we officially support type checking code targeting Python 3.10 and later, while Python 3.7 through 3.9 remain available (but only with best-effort behavior).

Closes https://github.com/astral-sh/ty/issues/878.
