### PR TITLE
Move Python support guidance to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,21 @@ ty uses `0.0.x` versioning. ty does not yet have a stable API; breaking changes,
 to diagnostics, may occur between any two versions. See the [type system support](https://github.com/astral-sh/ty/issues/1889)
 tracking issue for a detailed overview of currently supported features.
 
-ty officially supports type checking code that targets Python 3.10 and later. Earlier versions
-(Python 3.7 through 3.9) can still be selected, but may result in false negatives or false
-positives due to a lack of bundled standard library stubs.
-
 ## FAQ
 
 <!-- We intentionally use smaller headings for the FAQ items -->
 
 <!-- markdownlint-disable MD001 -->
+
+#### Which Python versions does ty support?
+
+ty officially supports type checking code that targets Python 3.10 and later. Earlier versions
+(Python 3.7 through 3.9) can still be selected, but may result in false negatives or false
+positives due to a lack of bundled standard library stubs.
+
+The target version is independent of the Python version used to install ty. For example, ty
+installed from PyPI using Python 3.8 or later can type check code targeting Python 3.7; the
+standalone installer does not require Python at all.
 
 #### Why is ty doing \_\_\_\_\_?
 


### PR DESCRIPTION
## Summary

Follow up on [review feedback from #3821](https://github.com/astral-sh/ty/pull/3821#discussion_r3452050257) by moving the Python-version support guidance from the Version policy section into a dedicated FAQ entry.

Clarify that the Python version targeted by ty is independent of the version used to install it: PyPI installations require Python 3.8 or later, while the standalone installer does not require Python.

The strict documentation build and Markdown formatting check pass.
