### PR TITLE
Document ty's `@Todo` type in the typing FAQ

### DIFF
--- a/docs/reference/typing-faq.md
+++ b/docs/reference/typing-faq.md
@@ -46,6 +46,20 @@ msg.data = {"color": "blue"}
 
 ([Full example in the playground](https://play.ty.dev/862941a8-a3f6-4818-9ea1-d9d59b0bd2fa))
 
+## What is the `@Todo` type and when does it appear?
+
+`@Todo` is ty's way of representing a type that cannot yet be inferred precisely because of a known
+missing feature or incomplete implementation in ty. Like `Any` and `Unknown`, it is a dynamic type,
+so ty allows any operation on it.
+
+Unlike `Any`, `@Todo` does not come from an explicit annotation. Unlike `Unknown`, it does not
+represent missing type information in the code being checked; instead, it indicates a limitation in
+ty itself. It may appear in type hints, `reveal_type()` output, or diagnostics. When an explanation
+appears in parentheses, such as `@Todo(TypeVarTuple)`, it identifies the missing feature.
+
+`@Todo` is an internal type and cannot be used in annotations. We aim to eliminate all `@Todo` types
+as we implement the missing functionality.
+
 ## What is the `Divergent` type and when does it appear?
 
 `Divergent` is ty's way of representing type-level recursion that does not converge. Type inference

--- a/docs/reference/typing-faq.md
+++ b/docs/reference/typing-faq.md
@@ -52,10 +52,9 @@ msg.data = {"color": "blue"}
 missing feature or incomplete implementation in ty. Like `Any` and `Unknown`, it is a dynamic type,
 so ty allows any operation on it.
 
-Unlike `Any`, `@Todo` does not come from an explicit annotation. Unlike `Unknown`, it does not
-represent missing type information in the code being checked; instead, it indicates a limitation in
-ty itself. It may appear in type hints, `reveal_type()` output, or diagnostics. When an explanation
-appears in parentheses, such as `@Todo(TypeVarTuple)`, it identifies the missing feature.
+Unlike `Any`, `@Todo` does not come from an explicit annotation. Unlike `Unknown`, it does
+not represent missing type information in the code being checked; instead, it indicates a
+limitation in ty itself. It may appear in type hints, `reveal_type()` output, or diagnostics.
 
 `@Todo` is an internal type and cannot be used in annotations. We aim to eliminate all `@Todo` types
 as we implement the missing functionality.


### PR DESCRIPTION
## Summary

Add a new FAQ entry explaining what `@Todo` means in ty's type system, how it differs from `Any` and `Unknown`, where it can appear, and why it cannot be used in annotations.

This complements https://github.com/astral-sh/ruff/pull/26324, which adds an editor navigation target for inferred `@Todo` types.

Part of: https://github.com/astral-sh/ty/issues/3209.
