### PR TITLE
Document the `fullDiagnosticOutput` extension to the Language Server Protocol

### DIFF
--- a/docs/features/language-server.md
+++ b/docs/features/language-server.md
@@ -150,6 +150,35 @@ within a few milliseconds, even on large projects.
 | [`workspace/symbol`][workspacesymbol]                 | ✅ Supported     |                                                               |
 | [`workspace/willRenameFiles`][willrenamefiles]        | ❌ Not supported | [#1560]                                                       |
 
+## LSP extensions
+
+ty also supports various nonstandard extensions to the Language Server Protocol. These extensions are a best-effort contract between the server and its clients; when in doubt, consult the implementation.
+
+Client capabilities for these extensions are advertised through the `experimental` field of [`ClientCapabilities`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities).
+
+### Full diagnostic output
+
+Experimental client capability: `{ "fullDiagnosticOutput": boolean }`
+
+When this capability is `true`, ty includes a human-readable multiline rendering of a diagnostic in the diagnostic's `data` field.
+
+```ts
+interface Diagnostic {
+    // Standard LSP fields omitted.
+    data?: {
+        /** A human-readable multiline rendering of the diagnostic. */
+        rendered?: string;
+
+        /** The original ty diagnostic identifier, such as `invalid-argument-type`. */
+        diagnostic_id?: string;
+
+        // Other ty-specific fields may also be present.
+    };
+}
+```
+
+For diagnostics that support this extension, `rendered` and `diagnostic_id` are either both present or both absent. Clients may use `diagnostic_id` to preserve the original identifier if they replace `Diagnostic.code` with a link to the rendered output. Clients must preserve `Diagnostic.data` when returning a diagnostic in a `textDocument/codeAction` request so that code actions continue to work.
+
 [#1560]: https://github.com/astral-sh/ty/issues/1560
 [#3514]: https://github.com/astral-sh/ty/issues/3514
 [callhierarchy]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls


### PR DESCRIPTION
## Summary

This documents the experimental LSP extension added in https://github.com/astral-sh/ruff/pull/26269 / https://github.com/astral-sh/ty-vscode/pull/462
