### PR TITLE
 Address EditorConfig violations

### DIFF
--- a/.ecformat_ignore
+++ b/.ecformat_ignore
@@ -1,0 +1,3 @@
+# Ignore submodule as checking for EditorConfig violations there
+# is its responsibility and out of scope for here
+ruff

--- a/.ecformat_ignore
+++ b/.ecformat_ignore
@@ -1,3 +1,7 @@
 # Ignore submodule as checking for EditorConfig violations there
 # is its responsibility and out of scope for here
 ruff
+
+# Ignore binary files
+*.ico
+*.png

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 4
 
 [*.md]
 max_line_length = 100
+
+[.gitmodules]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,16 @@ indent_size = 4
 
 [*.md]
 max_line_length = 100
+# Markdown has heavily context specific indentations.
+# For example, the indentation in lists depend on the length of the list marker
+# (such as '- ' or '100. '), at least in the GitHub Markdown flavor:
+# https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#nested-lists
+# Therefore, pressing tab should insert a single space to encourage situative accurate indentations.
+indent_size = 1
+
+[BENCHMARKS.md]
+# The CLI output contains many trailing spaces. Keep this output exactly as it is.
+trim_trailing_whitespace = false
 
 [.gitmodules]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_style = space
 insert_final_newline = true
 indent_size = 2
 
-[*.{rs,py,pyi,toml}]
+[*.{rs,py,pyi,toml,html,sh}]
 indent_size = 4
 
 [*.md]
@@ -25,6 +25,14 @@ indent_size = 1
 [BENCHMARKS.md]
 # The CLI output contains many trailing spaces. Keep this output exactly as it is.
 trim_trailing_whitespace = false
+
+[Dockerfile]
+indent_size = 4
+
+# You should NOT modify this file with your editor,
+# but if you do it anyway use the correct formatting.
+[uv.lock]
+indent_size = 4
 
 [.gitmodules]
 indent_style = tab

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -147,7 +147,7 @@ because the nav is in a hamburger menu anyway
       font-weight: normal;
       font-size: 0.85rem;
   }
-  /* Reducing spacing between nav items to fit more content 
+  /* Reducing spacing between nav items to fit more content
   First, disable `nav__link` spacing then use `nav__item` to enforce margins this reduces inconsistencies in the spacing. */
   .md-nav--primary .md-nav__link {
     margin: 0;
@@ -172,11 +172,11 @@ because the nav is in a hamburger menu anyway
   .md-nav__item--section> .md-nav > .md-nav__list > .md-nav__item > .md-nav > .md-nav__list > .md-nav__item:last-of-type {
     margin-bottom: 0.575em;
   }
-  /* Increase the size of the first nav item to match the sections 
+  /* Increase the size of the first nav item to match the sections
   It has no children, so it is not considered a section */
   .md-nav--primary > .md-nav__list > .md-nav__item:first-of-type {
     font-size: 0.85rem;
-    margin-bottom: 0.75em; 
+    margin-bottom: 0.75em;
   }
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,7 @@ plugins:
       timezone: UTC # It can only be in UTC unless the ISO time can include timezone.
   - llmstxt:
       markdown_description: |
-        ty is an extremely fast Python type checker and a language server written in Rust. 
+        ty is an extremely fast Python type checker and a language server written in Rust.
         It can type check large Python codebases in seconds, providing fast feedback
         during development.
 


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This Pull Request is part of an academic research project. More preciously it is for my master's thesis, more background information [here](https://codeberg.org/BaumiCoder/Masterthesis).

### Definition: EditorConfig violations

The goal of this Pull Request is to address all [EditorConfig](https://editorconfig.org) violations in the project. With EditorConfig you have set for example `trim_trailing_whitespace = true` for all files, but there were files with trailing spaces. I call this an EditorConfig violation as a file content violates the respective EditorConfig property. They can have different kind of impacts. For example trailing spaces, which get remove with the next save, may only make the next diff / Pull Request to this file less readable.

### How to address them?

To check for such violations and fix them I developed the CLI tool [ecformat](https://codeberg.org/BaumiCoder/ecformat). However, there are different ways to address the violations:

1. **Adjust EditorConfig:** The EditorConfig properties for a file can be wrong. For example git uses tabs for indentation in `.gitmodules`, but you set `indent_style = space` in your EditorConfig. However, it would be wrong to use spaces there as git always uses the tabs. The correct way to address that is to set `indent_style = tab` for this file, to avoid different indentation if ones may edit the file manually.
2. **Fix file content:** Another way is to fix the content of the file. Which means for `trim_trailing_whitespace = true` to remove the trailing spaces. To do so `ecformat fix` can be helpful.
3. **Ignore files:** For some files it is not meaningful to consider the EditorConfig violations, which `ecformat check` finds. I added a `.ecformat_ignore` file for this. It has the common ignore syntax such as a `.gitignore`. To use such ignore files, provide the name of them with an CLI switch, `ecformat check --ignore-file .ecformat_ignore`. (The `.gitignore` files are automatically considered inside a git repository.) There are different reasons to ignore files:
   1. The files belong the external repositories, such as submodules.
   2. As EditorConfig is only for text files, considering binary files does not make sense.
   3. EditorConfig supports to set the property on the file level. However, there can be files with intentional differences inside. A common example is that there is `indent_size = 2` set, but to align some code with the previous line an indentation / alignment uses for example 3 spaces. Detecting such cases as alignment and not as indentation needs language specific parsing, which is out of scope for a generic EditorConfig utility. Such files need to be ignored fully by `ecformat` as it currently (version 0.2.0) has no support to ignore only a single property for some files.

### Changes in this Pull Request

For this Pull Request, I addressed all violations in the project in the way, which looks the most correct one to me. (I focused on the Properties of the current [EditorConfig specification](https://spec.editorconfig.org/#supported-pairs) 0.17.2.) If I fixed file contents, I manually reviewed all of them, making adjustments in the `ecformat fix` changes were necessary.

If I picked the wrong way to address the violations for some files, please let me know with a respective Review comment. Then I will address it in the correct way. I add Review comments myself for special parts, which are especially worthy of discussion. To support the Review of this Pull Request, I tried to group the changes in meaningful commits with respective commit messages. Therefore, may take a look at the commit history.

### Avoid EditorConfig violations in the future

Such EditorConfig violations can creep in again. Possible reasons can be that the editor of some contributors has no EditorConfig support, or it would be required to install a respective plugin for the support.

If you want to avoid them in the future, I would suggest integrating a respective utility. For example as part of the CI, your pre-commit config or similar places. One possibility is to use `ecformat` with `ecformat check --ignore-file .ecformat_ignore`. Another one is [editorconfig-checker](https://editorconfig-checker.github.io), which is a more sophisticated tool without the possibility to fix violations. It provides more configuration options, such as ignoring violations in single lines with marker comments.

Let me know if you are interested using one of them. I could add one in this Pull Request or a follow-up Pull Request.
If you not consider to use `ecformat` in your project, the `.ecformat_ignore` file is maybe not worth to merge into main. I can remove it if desired.

## Test Plan

<!-- How was it tested? -->

As all changes are kind of formatting changes, I tried to test with prettier as documented in the CONTRIBUTING.md.

```shell
npx prettier --prose-wrap always --write "**/*.md"
```

However, this makes a lot of changes in many Markdown files, even in the `ruff` submodule. This also happens when I run it on the base revision of my feature branch (i.e., without my own changes). Is the use of prettier in this way correct or is the documentation about the usage out-dated?

Beside of this I took a rough look at the resulting web content and could not find any visible difference there.