### PR TITLE
Revert "Use ICF for macOS release builds"

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -87,10 +87,6 @@ jobs:
           maturin-version: v1.14.1
           target: x86_64
           args: --release --locked --out dist --compatibility pypi
-        env:
-          # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces the macOS x86_64 ty binary size by ~1.1%.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -134,10 +130,6 @@ jobs:
           maturin-version: v1.14.1
           target: aarch64
           args: --release --locked --out dist --compatibility pypi
-        env:
-          # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces the macOS aarch64 ty binary size by ~0.7%.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
           pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall


### PR DESCRIPTION
Reverts astral-sh/ty#3709 to see if this unblocks the release.