### PR TITLE
Bump version to 0.0.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 0.0.62
+
+Released on 2026-07-21.
+
+### Bug fixes
+
+- Guard recursive `Protocol` and `TypedDict` relations ([#26990](https://github.com/astral-sh/ruff/pull/26990))
+- Prevent stack overflows in recursive type relation checks ([#26503](https://github.com/astral-sh/ruff/pull/26503))
+- Recover from cancelled file indexing ([#26876](https://github.com/astral-sh/ruff/pull/26876))
+
+### Diagnostics
+
+- Avoid editing ignore comments with trailing reasons ([#26939](https://github.com/astral-sh/ruff/pull/26939))
+- Prefer innermost inline suppressions ([#26940](https://github.com/astral-sh/ruff/pull/26940))
+- Remove unused own-line ignore comments ([#27013](https://github.com/astral-sh/ruff/pull/27013))
+- Reuse applicable own-line suppressions in `--add-ignore` ([#26925](https://github.com/astral-sh/ruff/pull/26925))
+
+### Configuration
+
+- Respect `rules` and `analysis` in PEP 723 script metadata configurations ([#26671](https://github.com/astral-sh/ruff/pull/26671))
+
+### Core type checking
+
+- Accept gradual constrained TypeVar solutions ([#26965](https://github.com/astral-sh/ruff/pull/26965))
+- Avoid recursive TypeVarTuple alias expansion ([#27032](https://github.com/astral-sh/ruff/pull/27032))
+- Check inherited method conflicts via the MRO ([#27019](https://github.com/astral-sh/ruff/pull/27019))
+- Contextually infer custom `__setattr__` assignments ([#27015](https://github.com/astral-sh/ruff/pull/27015))
+- Fix `Callable` `isinstance` reachability ([#26970](https://github.com/astral-sh/ruff/pull/26970))
+- Fix `Just[float]` protocol matching ([#27053](https://github.com/astral-sh/ruff/pull/27053))
+- Fix `Self` binding for classmethod `__new__` constructors ([#27030](https://github.com/astral-sh/ruff/pull/27030))
+- Fix nested short-circuit flow snapshots ([#26956](https://github.com/astral-sh/ruff/pull/26956))
+- Gate `TypedDict` PEP 728 parameters by Python version ([#26968](https://github.com/astral-sh/ruff/pull/26968))
+- Improve `match` reachability inference around value-pattern branches ([#26979](https://github.com/astral-sh/ruff/pull/26979))
+- Make membership and equality narrowing consistent ([#26982](https://github.com/astral-sh/ruff/pull/26982))
+- Preserve constrained TypeVar equality narrowing ([#26988](https://github.com/astral-sh/ruff/pull/26988))
+- Preserve constrained TypeVar inequality narrowing ([#26995](https://github.com/astral-sh/ruff/pull/26995))
+- Preserve unsatisfiable generic call constraints ([#26964](https://github.com/astral-sh/ruff/pull/26964))
+- Respect bounded typevars in union inference ([#27023](https://github.com/astral-sh/ruff/pull/27023))
+- Respect metaclass `__setattr__` for class attributes ([#27000](https://github.com/astral-sh/ruff/pull/27000))
+
+### Performance
+
+- Cache non-terminal-call reachability prefixes ([#26810](https://github.com/astral-sh/ruff/pull/26810))
+- Cache protocol `Self` binding ([#26997](https://github.com/astral-sh/ruff/pull/26997))
+- Cache sparse reachability checkpoints ([#26811](https://github.com/astral-sh/ruff/pull/26811))
+- Defer statement-call narrowing gates ([#26793](https://github.com/astral-sh/ruff/pull/26793))
+
+### Contributors
+
+- [@charliermarsh](https://github.com/charliermarsh)
+- [@MichaReiser](https://github.com/MichaReiser)
+- [@carljm](https://github.com/carljm)
+- [@AlexWaygood](https://github.com/AlexWaygood)
+- [@mtshiba](https://github.com/mtshiba)
+
 ## 0.0.61
 
 Released on 2026-07-17.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["cargo:./ruff"]
 packages = ["ty"]
-version = "0.0.61"
+version = "0.0.62"
 
 # Config for 'dist'
 [dist]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ ty includes a standalone installer.
     Request a specific version by including it in the URL:
 
     ```console
-    $ curl -LsSf https://astral.sh/ty/0.0.61/install.sh | sh
+    $ curl -LsSf https://astral.sh/ty/0.0.62/install.sh | sh
     ```
 
 === "Windows"
@@ -87,7 +87,7 @@ ty includes a standalone installer.
     Request a specific version by including it in the URL:
 
     ```pwsh-session
-    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/ty/0.0.61/install.ps1 | iex"
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/ty/0.0.62/install.ps1 | iex"
     ```
 
 !!! tip
@@ -163,7 +163,7 @@ COPY --from=ghcr.io/astral-sh/ty:latest /ty /bin/
 The following tags are available:
 
 - `ghcr.io/astral-sh/ty:latest`
-- `ghcr.io/astral-sh/ty:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/ty:0.0.61`
+- `ghcr.io/astral-sh/ty:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/ty:0.0.62`
 - `ghcr.io/astral-sh/ty:{major}.{minor}`, e.g., `ghcr.io/astral-sh/ty:0.0` (the latest patch
     version)
 

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -165,7 +165,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.57">0.0.57</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22blanket-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L62" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L64" target="_blank">View source</a>
 </small>
 
 
@@ -832,7 +832,7 @@ INITIALIZED_CONSTANT: Final[int] = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ignore-comment-unknown-rule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L44" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L46" target="_blank">View source</a>
 </small>
 
 
@@ -1838,7 +1838,7 @@ x: G[int]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L53" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L55" target="_blank">View source</a>
 </small>
 
 
@@ -5069,7 +5069,7 @@ async def main() -> None:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L26" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L28" target="_blank">View source</a>
 </small>
 
 
@@ -5110,7 +5110,7 @@ to `false` to prevent this rule from reporting unused `type: ignore` comments.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-type-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L35" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L37" target="_blank">View source</a>
 </small>
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ty"
-version = "0.0.61"
+version = "0.0.62"
 requires-python = ">=3.8"
 dependencies = []
 description = "An extremely fast Python type checker, written in Rust."

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.61"
+version = "0.0.62"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Bump ty to 0.0.62, update the Ruff submodule and generated reference documentation, and organize the changelog by user-facing category.