### PR TITLE
README: Add link to Stable milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,13 @@ See the
 ## Version policy
 
 ty uses `0.0.x` versioning. ty does not yet have a stable API; breaking changes, including changes
-to diagnostics, may occur between any two versions. See the [type system support](https://github.com/astral-sh/ty/issues/1889)
+to diagnostics, may occur between any two versions.
+
+See the [type system support](https://github.com/astral-sh/ty/issues/1889)
 tracking issue for a detailed overview of currently supported features.
+
+For information on the timeline go to [When will ty be ready for production use?](https://github.com/astral-sh/ty/issues/1102)
+or check the milestone [Stable](https://github.com/astral-sh/ty/milestone/4)
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,10 @@ See the
 ## Version policy
 
 ty uses `0.0.x` versioning. ty does not yet have a stable API; breaking changes, including changes
-to diagnostics, may occur between any two versions.
-
-See the [type system support](https://github.com/astral-sh/ty/issues/1889)
+to diagnostics, may occur between any two versions. See the [type system support](https://github.com/astral-sh/ty/issues/1889)
 tracking issue for a detailed overview of currently supported features.
 
-For information on the timeline go to [When will ty be ready for production use?](https://github.com/astral-sh/ty/issues/1102)
-or check the milestone [Stable](https://github.com/astral-sh/ty/milestone/4)
+For information on the timeline, you can check out the [Stable](https://github.com/astral-sh/ty/milestone/4) milestone.
 
 ## FAQ
 


### PR DESCRIPTION
Add reference in readme to help user find reference to timeline

## Summary

Add reference in readme to help user find reference to timeline

Solves the comment:

> [NickCrews](https://github.com/NickCrews) [on Sep 2, 2025](https://github.com/astral-sh/ty/issues/1102#issuecomment-3245199222)
> Can you pin this issue or otherwise expose it more obviously in the readme and or docs? This took me a while to find. Thanks! You all are doing incredible work.

## Test Plan

Just a documentation update not a code modification, no test needed 