### PR TITLE
release: use self-repo references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run' }}
-    uses: ./.github/workflows/build-binaries.yml
+    uses: $/.github/workflows/build-binaries.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -127,7 +127,7 @@ jobs:
       - plan
       - release-gate
     if: ${{ always() && needs.plan.result == 'success' && (needs.release-gate.result == 'success' || needs.release-gate.result == 'skipped') && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run') }}
-    uses: ./.github/workflows/build-docker.yml
+    uses: $/.github/workflows/build-docker.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -239,7 +239,7 @@ jobs:
       - host
       - release-gate
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    uses: ./.github/workflows/publish-pypi.yml
+    uses: $/.github/workflows/publish-pypi.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -309,7 +309,7 @@ jobs:
     needs:
       - plan
       - announce
-    uses: ./.github/workflows/notify-dependents.yml
+    uses: $/.github/workflows/notify-dependents.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -318,7 +318,7 @@ jobs:
     needs:
       - plan
       - announce
-    uses: ./.github/workflows/publish-docs.yml
+    uses: $/.github/workflows/publish-docs.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -327,7 +327,7 @@ jobs:
     needs:
       - plan
       - announce
-    uses: ./.github/workflows/publish-versions.yml
+    uses: $/.github/workflows/publish-versions.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -336,7 +336,7 @@ jobs:
     needs:
       - plan
       - announce
-    uses: ./.github/workflows/publish-mirror.yml
+    uses: $/.github/workflows/publish-mirror.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Context: [github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)

See: https://github.com/astral-sh/uv/pull/20966

## Test Plan

NFC, CI only.
