### PR TITLE
Document the unsound-return-statement rule

### DIFF
--- a/docs/coming-from-mypy-or-pyright.md
+++ b/docs/coming-from-mypy-or-pyright.md
@@ -46,6 +46,7 @@ mode of other type checkers with the following configuration:
 [tool.ty.rules]
 missing-type-argument = "error"
 possibly-unresolved-reference = "warn"
+unsound-return-statement = "error"
 
 [tool.ruff.lint]
 extend-select = ["ANN", "PYI"]
@@ -54,7 +55,7 @@ preview = true
 
 This configuration:
 
-- Enables ty's disabled-by-default [`missing-type-argument`](https://docs.astral.sh/ty/reference/rules/#missing-type-argument) and [`possibly-unresolved-reference`](https://docs.astral.sh/ty/reference/rules/#possibly-unresolved-reference) rules
+- Enables ty's disabled-by-default [`missing-type-argument`](https://docs.astral.sh/ty/reference/rules/#missing-type-argument), [`possibly-unresolved-reference`](https://docs.astral.sh/ty/reference/rules/#possibly-unresolved-reference), and [`unsound-return-statement`](https://docs.astral.sh/ty/reference/rules/#unsound-return-statement) rules
 - Extends Ruff's default rules with the [`ANN`](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann) and [`PYI`](https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi) rule categories, both of which are focussed on type-annotating your code more effectively
 - Enables Ruff's preview mode so that `PYI033` also checks `.py` files
 
@@ -66,6 +67,7 @@ An even stricter configuration -- that goes beyond what mypy and pyright check f
 blanket-ignore-comment = "error"
 missing-type-argument = "error"
 possibly-unresolved-reference = "warn"
+unsound-return-statement = "error"
 unsupported-dynamic-base = "warn"
 
 # NOTE: the following rules are known to have a significant number of false positives,
@@ -150,6 +152,7 @@ emitted, or is folded into a broader category that already appears for another t
 | [`unresolved-attribute`][ty-unresolved-attribute]                                                                            | [`attr-defined`][mypy-attr-defined]<br>[`union-attr`][mypy-union-attr]                                                         | [`reportAttributeAccessIssue`][reportattributeaccessissue]<br>[`reportOptionalMemberAccess`][reportoptionalmemberaccess] |
 | [`unresolved-import`][ty-unresolved-import]                                                                                  | [`import-not-found`][mypy-import-not-found]                                                                                    | [`reportMissingImports`][reportmissingimports]                                                                           |
 | [`unresolved-reference`][ty-unresolved-reference]                                                                            | [`name-defined`][mypy-name-defined]                                                                                            | [`reportUndefinedVariable`][reportundefinedvariable]                                                                     |
+| [`unsound-return-statement`][ty-unsound-return-statement]                                                                    | [`no-any-return`][mypy-no-any-return]                                                                                          |                                                                                                                          |
 | [`unsupported-operator`][ty-unsupported-operator]                                                                            | [`operator`][mypy-operator]                                                                                                    | [`reportOperatorIssue`][reportoperatorissue]                                                                             |
 | [`unused-awaitable`][ty-unused-awaitable]                                                                                    | [`unused-coroutine`][mypy-unused-coroutine]<br>[`unused-awaitable`][mypy-unused-awaitable]                                     | [`reportUnusedCoroutine`][reportunusedcoroutine]                                                                         |
 | [`unused-ignore-comment`][ty-unused-ignore-comment]                                                                          | [`unused-ignore`][mypy-unused-ignore]                                                                                          | [`reportUnnecessaryTypeIgnoreComment`][reportunnecessarytypeignorecomment]                                               |
@@ -179,7 +182,6 @@ emitted, or is folded into a broader category that already appears for another t
 | [Ruff `PYI024`][ruff-pyi024]                                                                                                 |                                                                                                                                | [`reportUntypedNamedTuple`][reportuntypednamedtuple]                                                                     |
 | [Ruff `B018`][ruff-b018]                                                                                                     |                                                                                                                                | [`reportUnusedExpression`][reportunusedexpression]                                                                       |
 | [Ruff `F403`][ruff-f403]                                                                                                     |                                                                                                                                | [`reportWildcardImportFromLibrary`][reportwildcardimportfromlibrary]                                                     |
-| None yet                                                                                                                     | [`no-any-return`][mypy-no-any-return]                                                                                          |                                                                                                                          |
 | None yet                                                                                                                     | [`no-untyped-call`][mypy-no-untyped-call]                                                                                      |                                                                                                                          |
 | [Ruff `ANN` rules][ruff-ann]                                                                                                 | [`no-untyped-def`][mypy-no-untyped-def]                                                                                        | [`reportMissingParameterType`][reportmissingparametertype]<br>[`reportUnknownParameterType`][reportunknownparametertype] |
 | None yet                                                                                                                     | [`untyped-decorator`][mypy-untyped-decorator]                                                                                  | [`reportUntypedFunctionDecorator`][reportuntypedfunctiondecorator]                                                       |
@@ -368,6 +370,7 @@ The full list of ty rules — including those without a direct equivalent above 
 [ty-unresolved-attribute]: reference/rules.md#unresolved-attribute
 [ty-unresolved-import]: reference/rules.md#unresolved-import
 [ty-unresolved-reference]: reference/rules.md#unresolved-reference
+[ty-unsound-return-statement]: reference/rules.md#unsound-return-statement
 [ty-unsupported-operator]: reference/rules.md#unsupported-operator
 [ty-unused-awaitable]: reference/rules.md#unused-awaitable
 [ty-unused-ignore-comment]: reference/rules.md#unused-ignore-comment


### PR DESCRIPTION
Add `unsound-return-statement` to the recommended strict ty configurations and map it to mypy’s `no-any-return` error code.

The rule is disabled by default, so projects seeking strict-mode parity must enable it explicitly.