### PR TITLE
Enable PGO for Linux x86-64 ty releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -243,6 +243,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: "Install uv for PGO training"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: "Install LLVM profiling tools"
         id: pgo-toolchain
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -228,7 +228,7 @@ jobs:
 
   linux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && 'depot-ubuntu-24.04-8' || 'depot-ubuntu-24.04-4' }}
     strategy:
       matrix:
         target:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -258,7 +258,8 @@ jobs:
             --target-dir "${{ github.workspace }}/ruff/target/ty-pgo" \
             --train-only
 
-          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata" >> "$GITHUB_ENV"
+          PROFILE_HOT_COUNT="$(cat "${{ github.workspace }}/ruff/target/ty-pgo/ty.profile-hot-count")"
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata -Cllvm-args=--profile-summary-hot-count=$PROFILE_HOT_COUNT" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,6 +18,7 @@ on:
       - pyproject.toml
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
+      - scripts/build_ty_pgo.py
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -242,6 +243,22 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: "Install LLVM profiling tools"
+        id: pgo-toolchain
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        working-directory: ruff
+        run: |
+          rustup component add llvm-tools-preview
+          echo "toolchain=$(rustc --version | cut -d ' ' -f2)" >> "$GITHUB_OUTPUT"
+      - name: "Train PGO ty"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          python scripts/build_ty_pgo.py \
+            --target "${{ matrix.target }}" \
+            --target-dir "${{ github.workspace }}/ruff/target/ty-pgo" \
+            --train-only
+
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels"
@@ -249,6 +266,7 @@ jobs:
         with:
           maturin-version: v1.14.1
           target: ${{ matrix.target }}
+          rust-toolchain: ${{ steps.pgo-toolchain.outputs.toolchain }}
           manylinux: 2_17
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -1,16 +1,22 @@
-#!/usr/bin/env python3
 """Build ty with profile-guided optimization using pinned ecosystem projects."""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import selectors
+import queue
+import re
 import shlex
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,12 +26,23 @@ RUST_WORKSPACE_ROOT = REPOSITORY_ROOT / "ruff"
 EXCLUDED_DIRECTORIES = frozenset({"_tests", "_vendor", "test", "tests"})
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EcosystemProject:
     name: str
     repository: str
     revision: str
     source_directories: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if re.fullmatch(r"[0-9a-f]{40}", self.revision) is None:
+            raise ValueError(
+                f"{self.repository} must be pinned to a full Git commit SHA, "
+                f"got {self.revision!r}"
+            )
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{self.repository}.git"
 
 
 CORPUS_PROJECTS = (
@@ -106,20 +123,18 @@ def main() -> None:
         type=Path,
         help="Override the active Rust toolchain's llvm-profdata executable",
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--train-only",
         action="store_true",
         help="Only produce <target-dir>/ty.profdata for a subsequent release build",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--prepare-corpus",
         action="store_true",
         help="Only download and prepare the pinned ecosystem training corpus",
     )
     args = parser.parse_args()
-
-    if args.prepare_corpus and args.train_only:
-        parser.error("--prepare-corpus and --train-only cannot be used together")
 
     target_dir = (
         args.target_dir
@@ -174,11 +189,45 @@ def main() -> None:
     if not instrumented_binary.is_file():
         raise RuntimeError(f"Instrumented ty binary not found: {instrumented_binary}")
 
-    print(f"Training on {len(corpus)} ecosystem Python files", flush=True)
+    profiles = train_ty(
+        instrumented_binary,
+        target_dir / "corpus",
+        profile_dir,
+        corpus_size=len(corpus),
+        environment=instrumented_environment,
+    )
+    merge_profiles(profiler, profiles, merged_profile, environment=environment)
+
+    if args.train_only:
+        return
+
+    optimized_environment = environment | {
+        "CARGO_TARGET_DIR": str(target_dir),
+        "RUSTFLAGS": append_flags(
+            environment.get("RUSTFLAGS"), f"-Cprofile-use={merged_profile}"
+        ),
+    }
+    print("Building optimized release ty", flush=True)
+    run(cargo_command(target), environment=optimized_environment)
+    print(f"Optimized ty: {target_dir / target / 'release' / binary_name}", flush=True)
+
+
+def train_ty(
+    binary: Path,
+    corpus_directory: Path,
+    profile_directory: Path,
+    *,
+    corpus_size: int,
+    environment: dict[str, str],
+) -> list[Path]:
+    print(f"Training on {corpus_size} ecosystem Python files", flush=True)
+    profiles = []
     for project in CORPUS_PROJECTS:
-        checkout = target_dir / "corpus" / project.name
-        training_environment = instrumented_environment | {
-            "LLVM_PROFILE_FILE": str(profile_dir / f"ty-{project.name}-%m-%p.profraw")
+        checkout = corpus_directory / project.name
+        training_environment = environment | {
+            "LLVM_PROFILE_FILE": str(
+                profile_directory / f"ty-{project.name}-%m-%p.profraw"
+            )
         }
         for variable in (
             "CONDA_PREFIX",
@@ -193,14 +242,12 @@ def main() -> None:
         print(f"Profiling ty on {project.name}", flush=True)
         run(
             [
-                str(instrumented_binary),
+                str(binary),
                 "check",
                 "--project",
                 str(checkout),
                 "--python-version",
                 "3.13",
-                "--python-platform",
-                "linux",
                 *(
                     argument
                     for directory in sorted(EXCLUDED_DIRECTORIES)
@@ -214,22 +261,44 @@ def main() -> None:
             environment=training_environment,
         )
 
-    profile_language_server(instrumented_binary, profile_dir, instrumented_environment)
-
-    profiles = sorted(profile_dir.glob("ty-*.profraw"))
-    missing_workloads = [
-        name
-        for name in (*(project.name for project in CORPUS_PROJECTS), "language-server")
-        if not list(profile_dir.glob(f"ty-{name}-*.profraw"))
-    ]
-    if missing_workloads or any(profile.stat().st_size == 0 for profile in profiles):
-        raise RuntimeError(
-            f"Incomplete ty profiling data in {profile_dir}; "
-            f"missing workloads: {', '.join(missing_workloads) or 'none'}"
+        workload_profiles = sorted(
+            profile_directory.glob(f"ty-{project.name}-*.profraw")
         )
+        if not workload_profiles or any(
+            profile.stat().st_size == 0 for profile in workload_profiles
+        ):
+            raise RuntimeError(
+                f"No complete ty {project.name} profiling data found "
+                f"in {profile_directory}"
+            )
+        profiles.extend(workload_profiles)
+
+    profile_language_server(binary, profile_directory, environment)
+    language_server_profiles = sorted(
+        profile_directory.glob("ty-language-server-*.profraw")
+    )
+    if not language_server_profiles or any(
+        profile.stat().st_size == 0 for profile in language_server_profiles
+    ):
+        raise RuntimeError(
+            f"No complete ty language-server profiling data found "
+            f"in {profile_directory}"
+        )
+    profiles.extend(language_server_profiles)
+    return profiles
+
+
+def merge_profiles(
+    profiler: Path,
+    profiles: list[Path],
+    destination: Path,
+    *,
+    environment: dict[str, str],
+) -> None:
+    profile_size = sum(profile.stat().st_size for profile in profiles)
 
     with tempfile.NamedTemporaryFile(
-        dir=target_dir, prefix="ty-", suffix=".profdata", delete=False
+        dir=destination.parent, prefix="ty-", suffix=".profdata", delete=False
     ) as temporary_file:
         temporary_profile = Path(temporary_file.name)
     try:
@@ -243,23 +312,13 @@ def main() -> None:
             ],
             environment=environment,
         )
-        temporary_profile.replace(merged_profile)
+        temporary_profile.replace(destination)
     finally:
         temporary_profile.unlink(missing_ok=True)
-    print(f"Merged PGO profile: {merged_profile}", flush=True)
-
-    if args.train_only:
-        return
-
-    optimized_environment = environment | {
-        "CARGO_TARGET_DIR": str(target_dir),
-        "RUSTFLAGS": append_flags(
-            environment.get("RUSTFLAGS"), f"-Cprofile-use={merged_profile}"
-        ),
-    }
-    print("Building optimized release ty", flush=True)
-    run(cargo_command(target), environment=optimized_environment)
-    print(f"Optimized ty: {target_dir / target / 'release' / binary_name}", flush=True)
+    print(
+        f"Merged {len(profiles)} PGO profiles ({profile_size:,} bytes): {destination}",
+        flush=True,
+    )
 
 
 def profile_language_server(
@@ -321,9 +380,36 @@ def profile_language_server(
             process.wait()
             raise RuntimeError("Could not open language-server pipes")
 
-        selector = selectors.DefaultSelector()
-        selector.register(process.stdout, selectors.EVENT_READ)
+        responses: queue.Queue[dict[str, object] | Exception] = queue.Queue()
         request_id = 0
+
+        def read_responses() -> None:
+            try:
+                while True:
+                    headers: dict[str, str] = {}
+                    while True:
+                        line = process.stdout.readline()
+                        if not line:
+                            raise RuntimeError("Language server closed its output")
+                        if line in (b"\r\n", b"\n"):
+                            break
+                        name, _, value = line.decode("ascii").partition(":")
+                        headers[name.lower()] = value.strip()
+
+                    remaining = int(headers["content-length"])
+                    chunks: list[bytes] = []
+                    while remaining:
+                        chunk = process.stdout.read(remaining)
+                        if not chunk:
+                            raise RuntimeError("Language server closed its output")
+                        chunks.append(chunk)
+                        remaining -= len(chunk)
+                    response = json.loads(b"".join(chunks))
+                    if not isinstance(response, dict):
+                        raise RuntimeError("Expected a JSON-RPC response object")
+                    responses.put(response)
+            except (OSError, RuntimeError, UnicodeError, ValueError, KeyError) as error:
+                responses.put(error)
 
         def send(message: dict[str, object]) -> None:
             payload = json.dumps(message, separators=(",", ":")).encode("utf-8")
@@ -341,33 +427,18 @@ def profile_language_server(
             )
             deadline = time.monotonic() + 15
             while True:
-                headers: dict[str, str] = {}
-                while True:
-                    if not selector.select(max(0, deadline - time.monotonic())):
-                        raise TimeoutError(
-                            f"Language-server request timed out: {method}"
-                        )
-                    line = process.stdout.readline()
-                    if not line:
-                        raise RuntimeError("Language server closed its output")
-                    if line in (b"\r\n", b"\n"):
-                        break
-                    name, _, value = line.decode("ascii").partition(":")
-                    headers[name.lower()] = value.strip()
-
-                remaining = int(headers["content-length"])
-                chunks: list[bytes] = []
-                while remaining:
-                    if not selector.select(max(0, deadline - time.monotonic())):
-                        raise TimeoutError(
-                            f"Language-server response timed out: {method}"
-                        )
-                    chunk = process.stdout.read(remaining)
-                    if not chunk:
-                        raise RuntimeError("Language server closed its output")
-                    chunks.append(chunk)
-                    remaining -= len(chunk)
-                response = json.loads(b"".join(chunks))
+                try:
+                    response = responses.get(
+                        timeout=max(0, deadline - time.monotonic())
+                    )
+                except queue.Empty as error:
+                    raise TimeoutError(
+                        f"Language-server request timed out: {method}"
+                    ) from error
+                if isinstance(response, Exception):
+                    raise RuntimeError(
+                        "Could not read language-server output"
+                    ) from response
                 if "method" in response and "id" in response:
                     result = (
                         [] if response["method"] == "workspace/configuration" else None
@@ -389,6 +460,8 @@ def profile_language_server(
                 raise RuntimeError("Expected a full document diagnostic report")
             return result.get("items", [])
 
+        reader = threading.Thread(target=read_responses, daemon=True)
+        reader.start()
         try:
             initialized = request(
                 "initialize",
@@ -468,10 +541,10 @@ def profile_language_server(
                     process.stderr.read().decode("utf-8", errors="replace")
                 )
         finally:
-            selector.close()
             if process.poll() is None:
                 process.kill()
                 process.wait()
+            reader.join(timeout=1)
 
 
 def rustc_host() -> str:
@@ -535,9 +608,23 @@ def ecosystem_python_files(
                     "remote",
                     "add",
                     "origin",
-                    f"https://github.com/{project.repository}.git",
+                    project.url,
                 ],
                 environment=git_environment,
+            )
+
+        remote = subprocess.run(
+            [*git, "config", "--local", "--get", "remote.origin.url"],
+            cwd=REPOSITORY_ROOT,
+            env=git_environment,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if remote != project.url:
+            raise RuntimeError(
+                f"Unexpected origin for cached {project.name} checkout: "
+                f"expected {project.url}, got {remote}"
             )
 
         run(

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -45,6 +45,11 @@ class EcosystemProject:
         return f"https://github.com/{self.repository}.git"
 
 
+# Select a small, diverse sample from our linting and formatting ecosystem
+# checks: developer tools, web and scientific libraries, real applications,
+# and type stubs. Restrict each project to representative directories and pin
+# its commit for reproducibility. Keep held-out evaluation projects separate
+# so performance comparisons remain meaningful.
 CORPUS_PROJECTS = (
     EcosystemProject(
         name="pytest",
@@ -69,6 +74,22 @@ CORPUS_PROJECTS = (
         repository="agronholm/anyio",
         revision="ffe91331adb912c5d150f5d373f7cd28a0e96a62",
         source_directories=("src/anyio",),
+    ),
+    EcosystemProject(
+        name="zulip",
+        repository="zulip/zulip",
+        revision="ccddbba7a3074283ccaac3bde35fd32b19faf042",
+        source_directories=("zerver/views", "zerver/models"),
+    ),
+    EcosystemProject(
+        name="warehouse",
+        repository="pypi/warehouse",
+        revision="5a4d2cadec641b5d6a6847d0127940e0f532f184",
+        source_directories=(
+            "warehouse/accounts",
+            "warehouse/oidc",
+            "warehouse/forklift",
+        ),
     ),
     EcosystemProject(
         name="pip",

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 RUST_WORKSPACE_ROOT = REPOSITORY_ROOT / "ruff"
-PYTHON_VERSION = "3.14"
 DEPENDENCY_EXCLUDE_NEWER = "2026-08-06T08:40:30Z"
 EXCLUDED_DIRECTORIES = frozenset({"_tests", "_vendor", "test", "tests"})
 EXCLUDED_ENVIRONMENT_VARIABLES = (
@@ -47,6 +46,7 @@ class EcosystemProject:
     repository: str
     revision: str
     source_directories: tuple[str, ...]
+    python_version: str
     dependencies: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -54,6 +54,11 @@ class EcosystemProject:
             raise ValueError(
                 f"{self.repository} must be pinned to a full Git commit SHA, "
                 f"got {self.revision!r}"
+            )
+        if re.fullmatch(r"3\.\d+", self.python_version) is None:
+            raise ValueError(
+                f"{self.repository} must specify a Python major.minor version, "
+                f"got {self.python_version!r}"
             )
 
     @property
@@ -75,30 +80,35 @@ CORPUS_PROJECTS = (
         repository="pytest-dev/pytest",
         revision="28e86a6c2ae0173831e4925a4af89b02a2936d09",
         source_directories=("src/_pytest",),
+        python_version="3.10",
     ),
     EcosystemProject(
         name="httpx",
         repository="encode/httpx",
         revision="b5addb64f0161ff6bfe94c124ef76f6a1fba5254",
         source_directories=("httpx",),
+        python_version="3.9",
     ),
     EcosystemProject(
         name="fastapi",
         repository="fastapi/fastapi",
         revision="a375f6b948b99fa4260129856bbf11d037f363ef",
         source_directories=("fastapi",),
+        python_version="3.11",
     ),
     EcosystemProject(
         name="anyio",
         repository="agronholm/anyio",
         revision="ffe91331adb912c5d150f5d373f7cd28a0e96a62",
         source_directories=("src/anyio",),
+        python_version="3.10",
     ),
     EcosystemProject(
         name="zulip",
         repository="zulip/zulip",
         revision="ccddbba7a3074283ccaac3bde35fd32b19faf042",
         source_directories=("zerver/views", "zerver/models"),
+        python_version="3.10",
         dependencies=(
             "Django",
             "django-stubs",
@@ -120,6 +130,7 @@ CORPUS_PROJECTS = (
             "warehouse/oidc",
             "warehouse/forklift",
         ),
+        python_version="3.12",
         dependencies=(
             "pyramid",
             "pyramid-jinja2",
@@ -136,6 +147,7 @@ CORPUS_PROJECTS = (
         repository="pypa/pip",
         revision="d1fd55753405fd728a0751a578e27c1054acdf48",
         source_directories=("src/pip/_internal",),
+        python_version="3.10",
     ),
     EcosystemProject(
         name="sphinx",
@@ -146,12 +158,14 @@ CORPUS_PROJECTS = (
             "sphinx/ext/autodoc",
             "sphinx/domains/python",
         ),
+        python_version="3.12",
     ),
     EcosystemProject(
         name="astropy",
         repository="astropy/astropy",
         revision="b779108c7cec25c840c0f744fdf2a1550441e309",
         source_directories=("astropy/units",),
+        python_version="3.11",
     ),
     EcosystemProject(
         name="typeshed",
@@ -162,6 +176,7 @@ CORPUS_PROJECTS = (
             "stdlib/collections",
             "stubs/requests",
         ),
+        python_version="3.10",
     ),
 )
 
@@ -314,7 +329,7 @@ def train_ty(
                 "--project",
                 str(checkout),
                 "--python-version",
-                PYTHON_VERSION,
+                project.python_version,
                 *(
                     argument
                     for directory in sorted(EXCLUDED_DIRECTORIES)
@@ -375,7 +390,14 @@ def prepare_project_environments(
         )
         if not interpreter.is_file():
             run(
-                [uv, "venv", "--quiet", "--python", PYTHON_VERSION, str(destination)],
+                [
+                    uv,
+                    "venv",
+                    "--quiet",
+                    "--python",
+                    project.python_version,
+                    str(destination),
+                ],
                 environment=environment,
             )
 
@@ -491,7 +513,7 @@ def profile_language_server(
         root = Path(temporary)
         (root / "pyproject.toml").write_text(
             '[project]\nname = "ty-pgo"\nversion = "0.0.0"\n'
-            f'requires-python = ">={PYTHON_VERSION}"\n',
+            f'requires-python = ">={sys.version_info.major}.{sys.version_info.minor}"\n',
             encoding="utf-8",
         )
         models = root / "models.py"

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -233,6 +233,10 @@ def main() -> None:
         environment=instrumented_environment,
     )
     merge_profiles(profiler, profiles, merged_profile, environment=environment)
+    hot_count = profile_hot_count(profiler, merged_profile, environment=environment)
+    hot_count_path = target_dir / "ty.profile-hot-count"
+    hot_count_path.write_text(f"{hot_count}\n", encoding="utf-8", newline="\n")
+    print(f"Using 95th-percentile PGO hot count: {hot_count}", flush=True)
 
     if args.train_only:
         return
@@ -240,7 +244,9 @@ def main() -> None:
     optimized_environment = environment | {
         "CARGO_TARGET_DIR": str(target_dir),
         "RUSTFLAGS": append_flags(
-            environment.get("RUSTFLAGS"), f"-Cprofile-use={merged_profile}"
+            environment.get("RUSTFLAGS"),
+            f"-Cprofile-use={merged_profile} "
+            f"-Cllvm-args=--profile-summary-hot-count={hot_count}",
         ),
     }
     print("Building optimized release ty", flush=True)
@@ -348,6 +354,38 @@ def merge_profiles(
         f"Merged {len(profiles)} PGO profiles ({profile_size:,} bytes): {destination}",
         flush=True,
     )
+
+
+def profile_hot_count(
+    profiler: Path, profile: Path, *, environment: dict[str, str]
+) -> int:
+    # LLVM uses the 95th percentile for profile-guided size optimization, but
+    # defaults to the 99th percentile for hot-code optimization. Align them to
+    # avoid aggressively expanding moderately hot functions.
+    summary = subprocess.run(
+        [
+            str(profiler),
+            "show",
+            "--detailed-summary",
+            "--detailed-summary-cutoffs=950000",
+            str(profile),
+        ],
+        cwd=RUST_WORKSPACE_ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    match = re.search(
+        r"with count >= (\d+) account for 95% of the total counts\.", summary
+    )
+    if match is None:
+        raise RuntimeError("Could not determine the 95th-percentile PGO hot count")
+
+    count = int(match.group(1))
+    if count <= 0:
+        raise RuntimeError(f"PGO hot count must be positive, got {count}")
+    return count
 
 
 def profile_language_server(

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -50,8 +50,9 @@ class EcosystemProject:
 # corpus that includes scientific computing, synchronous and asynchronous code,
 # applications, libraries, and type stubs.
 #
-# Nothing in this list is sacred. During development, adding Zulip and Warehouse
-# reduced Ruff's CPU time by 0.35% while increasing its wheel size by 0.44%.
+# But it wasn't a highly optimized selection process. (For example, during
+# development, we added Zulip and Warehouse, which reduced Ruff's CPU time by
+# 0.35% while increasing its wheel size by 0.44%.)
 CORPUS_PROJECTS = (
     EcosystemProject(
         name="pytest",

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -45,11 +45,13 @@ class EcosystemProject:
         return f"https://github.com/{self.repository}.git"
 
 
-# Select a small, diverse sample from our linting and formatting ecosystem
-# checks: developer tools, web and scientific libraries, real applications,
-# and type stubs. Restrict each project to representative directories and pin
-# its commit for reproducibility. Keep held-out evaluation projects separate
-# so performance comparisons remain meaningful.
+# Train on a subset of the pinned ecosystem projects that we already use for
+# linting, formatting, or type checking. The goal is to create a representative
+# corpus that includes scientific computing, synchronous and asynchronous code,
+# applications, libraries, and type stubs.
+#
+# Nothing in this list is sacred. During development, adding Zulip and Warehouse
+# reduced Ruff's CPU time by 0.35% while increasing its wheel size by 0.44%.
 CORPUS_PROJECTS = (
     EcosystemProject(
         name="pytest",

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -13,17 +13,20 @@ import os
 import queue
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 RUST_WORKSPACE_ROOT = REPOSITORY_ROOT / "ruff"
 PYTHON_VERSION = "3.14"
+DEPENDENCY_EXCLUDE_NEWER = "2026-08-06T08:40:30Z"
 EXCLUDED_DIRECTORIES = frozenset({"_tests", "_vendor", "test", "tests"})
 EXCLUDED_ENVIRONMENT_VARIABLES = (
     "CONDA_PREFIX",
@@ -44,6 +47,7 @@ class EcosystemProject:
     repository: str
     revision: str
     source_directories: tuple[str, ...]
+    dependencies: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if re.fullmatch(r"[0-9a-f]{40}", self.revision) is None:
@@ -95,6 +99,17 @@ CORPUS_PROJECTS = (
         repository="zulip/zulip",
         revision="ccddbba7a3074283ccaac3bde35fd32b19faf042",
         source_directories=("zerver/views", "zerver/models"),
+        dependencies=(
+            "Django",
+            "django-stubs",
+            "pydantic",
+            "redis",
+            "orjson",
+            "requests",
+            "types-requests",
+            "PyYAML",
+            "types-PyYAML",
+        ),
     ),
     EcosystemProject(
         name="warehouse",
@@ -104,6 +119,16 @@ CORPUS_PROJECTS = (
             "warehouse/accounts",
             "warehouse/oidc",
             "warehouse/forklift",
+        ),
+        dependencies=(
+            "pyramid",
+            "pyramid-jinja2",
+            "sqlalchemy",
+            "pydantic",
+            "requests",
+            "redis",
+            "packaging",
+            "cryptography",
         ),
     ),
     EcosystemProject(
@@ -198,6 +223,9 @@ def main() -> None:
 
     profiler = find_llvm_profdata(host, args.llvm_profdata)
     corpus = ecosystem_python_files(target_dir / "corpus", environment=environment)
+    project_environments = prepare_project_environments(
+        target_dir / "environments", target_dir / "corpus", environment=environment
+    )
 
     profile_dir.mkdir(parents=True, exist_ok=True)
     for profile in profile_dir.glob("ty-*.profraw"):
@@ -230,6 +258,7 @@ def main() -> None:
         target_dir / "corpus",
         profile_dir,
         corpus_size=len(corpus),
+        project_environments=project_environments,
         environment=instrumented_environment,
     )
     merge_profiles(profiler, profiles, merged_profile, environment=environment)
@@ -260,6 +289,7 @@ def train_ty(
     profile_directory: Path,
     *,
     corpus_size: int,
+    project_environments: dict[str, Path],
     environment: dict[str, str],
 ) -> list[Path]:
     print(f"Training on {corpus_size} ecosystem Python files", flush=True)
@@ -279,6 +309,8 @@ def train_ty(
             [
                 str(binary),
                 "check",
+                "--python",
+                str(project_environments[project.name]),
                 "--project",
                 str(checkout),
                 "--python-version",
@@ -321,6 +353,61 @@ def train_ty(
         )
     profiles.extend(language_server_profiles)
     return profiles
+
+
+def prepare_project_environments(
+    environment_directory: Path,
+    corpus_directory: Path,
+    *,
+    environment: dict[str, str],
+) -> dict[str, Path]:
+    uv = shutil.which("uv", path=environment.get("PATH"))
+    if uv is None:
+        raise RuntimeError("uv is required to install PGO training dependencies")
+
+    environment_directory.mkdir(parents=True, exist_ok=True)
+    interpreters: dict[str, Path] = {}
+    for project in CORPUS_PROJECTS:
+        checkout = corpus_directory / project.name
+        destination = environment_directory / project.name
+        interpreter = destination / (
+            "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
+        )
+        if not interpreter.is_file():
+            run(
+                [uv, "venv", "--quiet", "--python", PYTHON_VERSION, str(destination)],
+                environment=environment,
+            )
+
+        manifest = checkout / "pyproject.toml"
+        if not manifest.is_file():
+            raise RuntimeError(f"Missing dependency metadata for {project.name}")
+        with manifest.open("rb") as stream:
+            metadata = tomllib.load(stream)
+
+        declared_dependencies = metadata.get("project", {}).get("dependencies", ())
+        if declared_dependencies or project.dependencies:
+            command = [
+                uv,
+                "pip",
+                "install",
+                "--quiet",
+                "--python",
+                str(interpreter),
+                "--only-binary",
+                ":all:",
+                "--exclude-newer",
+                DEPENDENCY_EXCLUDE_NEWER,
+            ]
+            if declared_dependencies:
+                command.extend(("--requirements", str(manifest)))
+            command.extend(project.dependencies)
+            print(f"Installing ty training dependencies for {project.name}", flush=True)
+            run(command, environment=environment)
+
+        interpreters[project.name] = interpreter
+
+    return interpreters
 
 
 def merge_profiles(

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -23,7 +23,19 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 RUST_WORKSPACE_ROOT = REPOSITORY_ROOT / "ruff"
+PYTHON_VERSION = "3.14"
 EXCLUDED_DIRECTORIES = frozenset({"_tests", "_vendor", "test", "tests"})
+EXCLUDED_ENVIRONMENT_VARIABLES = (
+    "CONDA_PREFIX",
+    "PYTHONPATH",
+    "TY_CONFIG_FILE",
+    "TY_LOG",
+    "TY_LOG_PROFILE",
+    "TY_OUTPUT_FORMAT",
+    "TY_UV",
+    "UV",
+    "VIRTUAL_ENV",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -253,14 +265,7 @@ def train_ty(
                 profile_directory / f"ty-{project.name}-%m-%p.profraw"
             )
         }
-        for variable in (
-            "CONDA_PREFIX",
-            "PYTHONPATH",
-            "TY_CONFIG_FILE",
-            "TY_LOG",
-            "TY_OUTPUT_FORMAT",
-            "VIRTUAL_ENV",
-        ):
+        for variable in EXCLUDED_ENVIRONMENT_VARIABLES:
             training_environment.pop(variable, None)
 
         print(f"Profiling ty on {project.name}", flush=True)
@@ -271,7 +276,7 @@ def train_ty(
                 "--project",
                 str(checkout),
                 "--python-version",
-                "3.13",
+                PYTHON_VERSION,
                 *(
                     argument
                     for directory in sorted(EXCLUDED_DIRECTORIES)
@@ -352,17 +357,7 @@ def profile_language_server(
     server_environment = environment | {
         "LLVM_PROFILE_FILE": str(profile_directory / "ty-language-server-%m-%p.profraw")
     }
-    for variable in (
-        "CONDA_PREFIX",
-        "PYTHONPATH",
-        "TY_CONFIG_FILE",
-        "TY_LOG",
-        "TY_LOG_PROFILE",
-        "TY_OUTPUT_FORMAT",
-        "TY_UV",
-        "UV",
-        "VIRTUAL_ENV",
-    ):
+    for variable in EXCLUDED_ENVIRONMENT_VARIABLES:
         server_environment.pop(variable, None)
 
     with tempfile.TemporaryDirectory(
@@ -371,7 +366,7 @@ def profile_language_server(
         root = Path(temporary)
         (root / "pyproject.toml").write_text(
             '[project]\nname = "ty-pgo"\nversion = "0.0.0"\n'
-            'requires-python = ">=3.12"\n',
+            f'requires-python = ">={PYTHON_VERSION}"\n',
             encoding="utf-8",
         )
         models = root / "models.py"

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Build ty with profile-guided optimization using pinned ecosystem projects."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+RUST_WORKSPACE_ROOT = REPOSITORY_ROOT / "ruff"
+EXCLUDED_DIRECTORIES = frozenset({"_tests", "_vendor", "test", "tests"})
+
+
+@dataclass(frozen=True)
+class EcosystemProject:
+    name: str
+    repository: str
+    revision: str
+    source_directories: tuple[str, ...]
+
+
+CORPUS_PROJECTS = (
+    EcosystemProject(
+        name="pytest",
+        repository="pytest-dev/pytest",
+        revision="28e86a6c2ae0173831e4925a4af89b02a2936d09",
+        source_directories=("src/_pytest",),
+    ),
+    EcosystemProject(
+        name="httpx",
+        repository="encode/httpx",
+        revision="b5addb64f0161ff6bfe94c124ef76f6a1fba5254",
+        source_directories=("httpx",),
+    ),
+    EcosystemProject(
+        name="fastapi",
+        repository="fastapi/fastapi",
+        revision="a375f6b948b99fa4260129856bbf11d037f363ef",
+        source_directories=("fastapi",),
+    ),
+    EcosystemProject(
+        name="anyio",
+        repository="agronholm/anyio",
+        revision="ffe91331adb912c5d150f5d373f7cd28a0e96a62",
+        source_directories=("src/anyio",),
+    ),
+    EcosystemProject(
+        name="pip",
+        repository="pypa/pip",
+        revision="d1fd55753405fd728a0751a578e27c1054acdf48",
+        source_directories=("src/pip/_internal",),
+    ),
+    EcosystemProject(
+        name="sphinx",
+        repository="sphinx-doc/sphinx",
+        revision="b06d92e80eed130e1dd4e67cac4afa1267424f1a",
+        source_directories=(
+            "sphinx/builders",
+            "sphinx/ext/autodoc",
+            "sphinx/domains/python",
+        ),
+    ),
+    EcosystemProject(
+        name="astropy",
+        repository="astropy/astropy",
+        revision="b779108c7cec25c840c0f744fdf2a1550441e309",
+        source_directories=("astropy/units",),
+    ),
+    EcosystemProject(
+        name="typeshed",
+        repository="python/typeshed",
+        revision="e0efbeef901e9b6998d016e1ab9352678f09ae77",
+        source_directories=(
+            "stdlib/asyncio",
+            "stdlib/collections",
+            "stubs/requests",
+        ),
+    ),
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", help="Host-native Rust target triple")
+    parser.add_argument(
+        "--target-dir",
+        type=Path,
+        help="Cargo target directory (default: CARGO_TARGET_DIR or ruff/target/ty-pgo)",
+    )
+    parser.add_argument(
+        "--profile-dir",
+        type=Path,
+        help="Raw profile directory (default: <target-dir>/profiles)",
+    )
+    parser.add_argument(
+        "--llvm-profdata",
+        type=Path,
+        help="Override the active Rust toolchain's llvm-profdata executable",
+    )
+    parser.add_argument(
+        "--train-only",
+        action="store_true",
+        help="Only produce <target-dir>/ty.profdata for a subsequent release build",
+    )
+    parser.add_argument(
+        "--prepare-corpus",
+        action="store_true",
+        help="Only download and prepare the pinned ecosystem training corpus",
+    )
+    args = parser.parse_args()
+
+    if args.prepare_corpus and args.train_only:
+        parser.error("--prepare-corpus and --train-only cannot be used together")
+
+    target_dir = (
+        args.target_dir
+        or Path(
+            os.environ.get(
+                "CARGO_TARGET_DIR", RUST_WORKSPACE_ROOT / "target" / "ty-pgo"
+            )
+        )
+    ).resolve()
+    profile_dir = (args.profile_dir or target_dir / "profiles").resolve()
+    merged_profile = target_dir / "ty.profdata"
+
+    environment = os.environ.copy()
+    if args.prepare_corpus:
+        corpus = ecosystem_python_files(target_dir / "corpus", environment=environment)
+        print(f"Prepared {len(corpus)} ecosystem Python files", flush=True)
+        return
+
+    host = rustc_host()
+    target = args.target or host
+    if target != host:
+        parser.error(
+            f"PGO training requires the host-native target {host}, got {target}"
+        )
+
+    profiler = find_llvm_profdata(host, args.llvm_profdata)
+    corpus = ecosystem_python_files(target_dir / "corpus", environment=environment)
+
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    for profile in profile_dir.glob("ty-*.profraw"):
+        profile.unlink()
+
+    environment["CARGO_INCREMENTAL"] = "0"
+    if target.endswith("-apple-darwin"):
+        for variable in ("CFLAGS", "CXXFLAGS"):
+            environment[variable] = append_flags(
+                environment.get(variable), "-fno-profile-generate -fno-profile-use"
+            )
+
+    instrumented_target_dir = target_dir / "instrumented"
+    instrumented_environment = environment | {
+        "CARGO_TARGET_DIR": str(instrumented_target_dir),
+        "RUSTFLAGS": append_flags(
+            environment.get("RUSTFLAGS"), f"-Cprofile-generate={profile_dir}"
+        ),
+    }
+    print("Building instrumented release ty", flush=True)
+    run(cargo_command(target), environment=instrumented_environment)
+
+    binary_name = "ty.exe" if "windows" in target else "ty"
+    instrumented_binary = instrumented_target_dir / target / "release" / binary_name
+    if not instrumented_binary.is_file():
+        raise RuntimeError(f"Instrumented ty binary not found: {instrumented_binary}")
+
+    print(f"Training on {len(corpus)} ecosystem Python files", flush=True)
+    for project in CORPUS_PROJECTS:
+        checkout = target_dir / "corpus" / project.name
+        training_environment = instrumented_environment | {
+            "LLVM_PROFILE_FILE": str(profile_dir / f"ty-{project.name}-%m-%p.profraw")
+        }
+        for variable in (
+            "CONDA_PREFIX",
+            "PYTHONPATH",
+            "TY_CONFIG_FILE",
+            "TY_LOG",
+            "TY_OUTPUT_FORMAT",
+            "VIRTUAL_ENV",
+        ):
+            training_environment.pop(variable, None)
+
+        print(f"Profiling ty on {project.name}", flush=True)
+        run(
+            [
+                str(instrumented_binary),
+                "check",
+                "--project",
+                str(checkout),
+                "--python-version",
+                "3.13",
+                "--python-platform",
+                "linux",
+                *(
+                    argument
+                    for directory in sorted(EXCLUDED_DIRECTORIES)
+                    for argument in ("--exclude", f"{directory}/")
+                ),
+                "--exit-zero",
+                "--no-progress",
+                "-qq",
+                *(str(checkout / source) for source in project.source_directories),
+            ],
+            environment=training_environment,
+        )
+
+    profiles = sorted(profile_dir.glob("ty-*.profraw"))
+    missing_projects = [
+        project.name
+        for project in CORPUS_PROJECTS
+        if not list(profile_dir.glob(f"ty-{project.name}-*.profraw"))
+    ]
+    if missing_projects or any(profile.stat().st_size == 0 for profile in profiles):
+        raise RuntimeError(
+            f"Incomplete ty profiling data in {profile_dir}; "
+            f"missing projects: {', '.join(missing_projects) or 'none'}"
+        )
+
+    with tempfile.NamedTemporaryFile(
+        dir=target_dir, prefix="ty-", suffix=".profdata", delete=False
+    ) as temporary_file:
+        temporary_profile = Path(temporary_file.name)
+    try:
+        run(
+            [
+                str(profiler),
+                "merge",
+                "--output",
+                str(temporary_profile),
+                *map(str, profiles),
+            ],
+            environment=environment,
+        )
+        temporary_profile.replace(merged_profile)
+    finally:
+        temporary_profile.unlink(missing_ok=True)
+    print(f"Merged PGO profile: {merged_profile}", flush=True)
+
+    if args.train_only:
+        return
+
+    optimized_environment = environment | {
+        "CARGO_TARGET_DIR": str(target_dir),
+        "RUSTFLAGS": append_flags(
+            environment.get("RUSTFLAGS"), f"-Cprofile-use={merged_profile}"
+        ),
+    }
+    print("Building optimized release ty", flush=True)
+    run(cargo_command(target), environment=optimized_environment)
+    print(f"Optimized ty: {target_dir / target / 'release' / binary_name}", flush=True)
+
+
+def rustc_host() -> str:
+    version = subprocess.run(
+        ["rustc", "--version", "--verbose"],
+        cwd=RUST_WORKSPACE_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    for line in version.splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise RuntimeError("Could not determine the active Rust compiler's host target")
+
+
+def find_llvm_profdata(host: str, override: Path | None) -> Path:
+    if override is not None:
+        profiler = override.resolve()
+    else:
+        sysroot = subprocess.run(
+            ["rustc", "--print", "sysroot"],
+            cwd=RUST_WORKSPACE_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        binary_name = "llvm-profdata.exe" if "windows" in host else "llvm-profdata"
+        profiler = Path(sysroot) / "lib" / "rustlib" / host / "bin" / binary_name
+
+    if not profiler.is_file() or not os.access(profiler, os.X_OK):
+        raise RuntimeError(
+            f"Rust toolchain llvm-profdata not found: {profiler}; "
+            "run `rustup component add llvm-tools-preview`"
+        )
+    return profiler
+
+
+def ecosystem_python_files(
+    corpus_directory: Path, *, environment: dict[str, str]
+) -> list[str]:
+    corpus_directory.mkdir(parents=True, exist_ok=True)
+    git_environment = environment | {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_LFS_SKIP_SMUDGE": "1",
+    }
+    paths: list[str] = []
+
+    for project in CORPUS_PROJECTS:
+        checkout = corpus_directory / project.name
+        checkout.mkdir(parents=True, exist_ok=True)
+        git = ["git", "-c", f"core.hooksPath={os.devnull}", "-C", str(checkout)]
+
+        if not (checkout / ".git").is_dir():
+            print(f"Preparing {project.repository}@{project.revision}", flush=True)
+            run([*git, "init", "--quiet"], environment=git_environment)
+            run(
+                [
+                    *git,
+                    "remote",
+                    "add",
+                    "origin",
+                    f"https://github.com/{project.repository}.git",
+                ],
+                environment=git_environment,
+            )
+
+        run(
+            [*git, "sparse-checkout", "set", "--cone", *project.source_directories],
+            environment=git_environment,
+        )
+
+        current_revision = subprocess.run(
+            [*git, "rev-parse", "--verify", "HEAD"],
+            cwd=REPOSITORY_ROOT,
+            env=git_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if (
+            current_revision.returncode != 0
+            or current_revision.stdout.strip() != project.revision
+        ):
+            run_git_with_retry(
+                [
+                    *git,
+                    "fetch",
+                    "--quiet",
+                    "--no-tags",
+                    "--no-recurse-submodules",
+                    "--depth=1",
+                    "--filter=blob:none",
+                    "origin",
+                    project.revision,
+                ],
+                environment=git_environment,
+            )
+
+        run_git_with_retry(
+            [
+                *git,
+                "checkout",
+                "--quiet",
+                "--detach",
+                "--force",
+                "--no-recurse-submodules",
+                project.revision,
+            ],
+            environment=git_environment,
+        )
+
+        for source_directory in project.source_directories:
+            source = checkout / source_directory
+            if not source.is_dir():
+                raise RuntimeError(
+                    f"Missing training source directory {source_directory!r} "
+                    f"in {project.repository}@{project.revision}"
+                )
+
+        tracked_files = subprocess.run(
+            [*git, "ls-files", "-z", "--", *project.source_directories],
+            cwd=REPOSITORY_ROOT,
+            env=git_environment,
+            check=True,
+            capture_output=True,
+        ).stdout.split(b"\0")
+        project_paths = [
+            str(path)
+            for tracked_file in tracked_files
+            if tracked_file
+            and (path := checkout / os.fsdecode(tracked_file)).suffix in {".py", ".pyi"}
+            and path.is_file()
+            and not path.is_symlink()
+            and not EXCLUDED_DIRECTORIES.intersection(
+                path.relative_to(checkout).parts[:-1]
+            )
+        ]
+
+        if not project_paths:
+            raise RuntimeError(
+                f"No Python training files found in {project.repository}"
+            )
+        paths.extend(sorted(project_paths))
+        print(f"  {project.name}: {len(project_paths)} Python files", flush=True)
+
+    return paths
+
+
+def run_git_with_retry(command: list[str], *, environment: dict[str, str]) -> None:
+    for attempt in range(3):
+        try:
+            run(command, environment=environment)
+            return
+        except subprocess.CalledProcessError:
+            if attempt == 2:
+                raise
+            delay = 2**attempt
+            print(
+                f"Git command failed; retrying in {delay}s (attempt {attempt + 2} of 3)",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(delay)
+
+
+def cargo_command(target: str) -> list[str]:
+    return [
+        "cargo",
+        "rustc",
+        "--release",
+        "--locked",
+        "--package",
+        "ty",
+        "--bin",
+        "ty",
+        "--target",
+        target,
+        "--",
+        "-C",
+        "strip=symbols",
+    ]
+
+
+def append_flags(existing: str | None, additional: str) -> str:
+    return " ".join(flag for flag in (existing, additional) if flag)
+
+
+def run(
+    command: list[str],
+    *,
+    environment: dict[str, str],
+    allowed_exit_codes: tuple[int, ...] = (0,),
+) -> None:
+    logged_arguments = 16
+    displayed_command = shlex.join(command[:logged_arguments])
+    if len(command) > logged_arguments:
+        displayed_command += (
+            f" ... ({len(command) - logged_arguments} arguments omitted)"
+        )
+    print(f"> {displayed_command}", flush=True)
+    completed = subprocess.run(
+        command, cwd=RUST_WORKSPACE_ROOT, env=environment, check=False
+    )
+    if completed.returncode not in allowed_exit_codes:
+        raise subprocess.CalledProcessError(completed.returncode, command)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import selectors
 import shlex
 import subprocess
 import sys
@@ -212,16 +214,18 @@ def main() -> None:
             environment=training_environment,
         )
 
+    profile_language_server(instrumented_binary, profile_dir, instrumented_environment)
+
     profiles = sorted(profile_dir.glob("ty-*.profraw"))
-    missing_projects = [
-        project.name
-        for project in CORPUS_PROJECTS
-        if not list(profile_dir.glob(f"ty-{project.name}-*.profraw"))
+    missing_workloads = [
+        name
+        for name in (*(project.name for project in CORPUS_PROJECTS), "language-server")
+        if not list(profile_dir.glob(f"ty-{name}-*.profraw"))
     ]
-    if missing_projects or any(profile.stat().st_size == 0 for profile in profiles):
+    if missing_workloads or any(profile.stat().st_size == 0 for profile in profiles):
         raise RuntimeError(
             f"Incomplete ty profiling data in {profile_dir}; "
-            f"missing projects: {', '.join(missing_projects) or 'none'}"
+            f"missing workloads: {', '.join(missing_workloads) or 'none'}"
         )
 
     with tempfile.NamedTemporaryFile(
@@ -256,6 +260,218 @@ def main() -> None:
     print("Building optimized release ty", flush=True)
     run(cargo_command(target), environment=optimized_environment)
     print(f"Optimized ty: {target_dir / target / 'release' / binary_name}", flush=True)
+
+
+def profile_language_server(
+    binary: Path, profile_directory: Path, environment: dict[str, str]
+) -> None:
+    print("Profiling ty language-server incremental edits", flush=True)
+    server_environment = environment | {
+        "LLVM_PROFILE_FILE": str(profile_directory / "ty-language-server-%m-%p.profraw")
+    }
+    for variable in (
+        "CONDA_PREFIX",
+        "PYTHONPATH",
+        "TY_CONFIG_FILE",
+        "TY_LOG",
+        "TY_LOG_PROFILE",
+        "TY_OUTPUT_FORMAT",
+        "TY_UV",
+        "UV",
+        "VIRTUAL_ENV",
+    ):
+        server_environment.pop(variable, None)
+
+    with tempfile.TemporaryDirectory(
+        prefix="ty-pgo-language-server-", dir=profile_directory.parent
+    ) as temporary:
+        root = Path(temporary)
+        (root / "pyproject.toml").write_text(
+            '[project]\nname = "ty-pgo"\nversion = "0.0.0"\n'
+            'requires-python = ">=3.12"\n',
+            encoding="utf-8",
+        )
+        models = root / "models.py"
+        models_text = (
+            "from dataclasses import dataclass\n\n"
+            "@dataclass\nclass User:\n    name: str\n    age: int\n\n"
+            'def load_user() -> User:\n    return User("Ada", 37)\n'
+        )
+        models.write_text(models_text, encoding="utf-8")
+        service = root / "service.py"
+        service_text = (
+            "from models import User, load_user\n\n"
+            "def describe(user: User) -> str:\n    return user.name.upper()\n\n"
+            "user = load_user()\nresult = describe(user)\n"
+            "next_age = user.age + 1\n"
+        )
+        service.write_text(service_text, encoding="utf-8")
+
+        process = subprocess.Popen(
+            [str(binary), "server"],
+            cwd=root,
+            env=server_environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        if process.stdin is None or process.stdout is None or process.stderr is None:
+            process.kill()
+            process.wait()
+            raise RuntimeError("Could not open language-server pipes")
+
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ)
+        request_id = 0
+
+        def send(message: dict[str, object]) -> None:
+            payload = json.dumps(message, separators=(",", ":")).encode("utf-8")
+            process.stdin.write(
+                f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
+            )
+            process.stdin.write(payload)
+
+        def request(method: str, params: dict[str, object] | None = None) -> object:
+            nonlocal request_id
+            request_id += 1
+            identifier = request_id
+            send(
+                {"jsonrpc": "2.0", "id": identifier, "method": method, "params": params}
+            )
+            deadline = time.monotonic() + 15
+            while True:
+                headers: dict[str, str] = {}
+                while True:
+                    if not selector.select(max(0, deadline - time.monotonic())):
+                        raise TimeoutError(
+                            f"Language-server request timed out: {method}"
+                        )
+                    line = process.stdout.readline()
+                    if not line:
+                        raise RuntimeError("Language server closed its output")
+                    if line in (b"\r\n", b"\n"):
+                        break
+                    name, _, value = line.decode("ascii").partition(":")
+                    headers[name.lower()] = value.strip()
+
+                remaining = int(headers["content-length"])
+                chunks: list[bytes] = []
+                while remaining:
+                    if not selector.select(max(0, deadline - time.monotonic())):
+                        raise TimeoutError(
+                            f"Language-server response timed out: {method}"
+                        )
+                    chunk = process.stdout.read(remaining)
+                    if not chunk:
+                        raise RuntimeError("Language server closed its output")
+                    chunks.append(chunk)
+                    remaining -= len(chunk)
+                response = json.loads(b"".join(chunks))
+                if "method" in response and "id" in response:
+                    result = (
+                        [] if response["method"] == "workspace/configuration" else None
+                    )
+                    send({"jsonrpc": "2.0", "id": response["id"], "result": result})
+                elif response.get("id") == identifier:
+                    if "error" in response:
+                        raise RuntimeError(f"{method} failed: {response['error']}")
+                    return response.get("result")
+
+        def notify(method: str, params: dict[str, object] | None = None) -> None:
+            send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+        def diagnostics(path: Path) -> list[object]:
+            result = request(
+                "textDocument/diagnostic", {"textDocument": {"uri": path.as_uri()}}
+            )
+            if not isinstance(result, dict):
+                raise RuntimeError("Expected a full document diagnostic report")
+            return result.get("items", [])
+
+        try:
+            initialized = request(
+                "initialize",
+                {
+                    "processId": os.getpid(),
+                    "rootUri": root.as_uri(),
+                    "workspaceFolders": [{"uri": root.as_uri(), "name": root.name}],
+                    "capabilities": {
+                        "workspace": {"configuration": False},
+                        "textDocument": {"diagnostic": {"dynamicRegistration": False}},
+                    },
+                },
+            )
+            if not isinstance(initialized, dict) or not initialized.get(
+                "capabilities", {}
+            ).get("diagnosticProvider"):
+                raise RuntimeError("Language server does not support pull diagnostics")
+            notify("initialized")
+
+            for path, text in ((models, models_text), (service, service_text)):
+                notify(
+                    "textDocument/didOpen",
+                    {
+                        "textDocument": {
+                            "uri": path.as_uri(),
+                            "languageId": "python",
+                            "version": 1,
+                            "text": text,
+                        }
+                    },
+                )
+            if diagnostics(models) or diagnostics(service):
+                raise RuntimeError("Expected clean initial language-server diagnostics")
+
+            for method, position in (
+                ("textDocument/hover", {"line": 7, "character": 17}),
+                ("textDocument/definition", {"line": 5, "character": 8}),
+                ("textDocument/completion", {"line": 5, "character": 16}),
+            ):
+                result = request(
+                    method,
+                    {"textDocument": {"uri": service.as_uri()}, "position": position},
+                )
+                if not result:
+                    raise RuntimeError(f"Expected a nonempty {method} result")
+
+            for index in range(12):
+                invalid = index % 2 == 0
+                changed = (
+                    models_text.replace("age: int", "age: str")
+                    if invalid
+                    else models_text
+                )
+                notify(
+                    "textDocument/didChange",
+                    {
+                        "textDocument": {
+                            "uri": models.as_uri(),
+                            "version": index + 2,
+                        },
+                        "contentChanges": [{"text": changed}],
+                    },
+                )
+                if (
+                    bool(diagnostics(models)) != invalid
+                    or bool(diagnostics(service)) != invalid
+                ):
+                    raise RuntimeError(
+                        "Incremental cross-file diagnostics did not update"
+                    )
+
+            request("shutdown")
+            notify("exit")
+            process.stdin.close()
+            if process.wait(timeout=10):
+                raise RuntimeError(
+                    process.stderr.read().decode("utf-8", errors="replace")
+                )
+        finally:
+            selector.close()
+            if process.poll() is None:
+                process.kill()
+                process.wait()
 
 
 def rustc_host() -> str:


### PR DESCRIPTION
## Summary

This PR enables PGO for ty releases, starting with Linux x86-64. The approach follows that outlined in https://github.com/astral-sh/ruff/pull/27570.

### Design

The release pipeline is modified as follows:

- We build an instrumented release binary using the Rust toolchain pinned by the Ruff submodule.
- We run `ty check` on the same ten pinned ecosystem projects used by Ruff. In total, the corpus contains 618 Python and stub files.
- We also exercise `ty server` against a temporary project, covering diagnostics, hover, go-to-definition, completion, and incremental cross-file edits.
- We merge the profiles via `llvm-profdata`.
- We derive LLVM's hot-code threshold from the profile's 95th percentile, matching its size-optimization threshold and avoiding unnecessary expansion of moderately hot functions. (Without this, performance was marginally better, but wheel size _increased_ by 5-10%!)
- We feed the result back into the existing `maturin` build.

### Results

Here's the initial, untuned PGO performance on seven held-out projects (and language-server performance on three held-out projects):

| Held-out project | `ty check` | Incremental edits |
| --- | ---: | ---: |
| Black | 7.1% faster | 17.1% faster |
| isort | 13.3% faster | 18.1% faster |
| Jinja | 5.5% faster | 13.7% faster |
| Django | 25.5% faster | — |
| pandas | 15.9% faster | — |
| scikit-learn | 19.6% faster | — |
| SymPy | 21.5% faster | — |
| Geometric mean | **15.8% faster** | **16.3% faster** |

As an aside, profiling the language server explicitly (i.e., including the language server commands in the PGO training) improved incremental-edit latency by another 7.6% over CLI-only PGO; without that training, incremental edit performance was _still_ up (but not quite as much).

Beyond raw performance, with the tuned PGO settings, we see the following results:

- **Binary size decreased by 7.98%** (28.10 MB to 25.86 MB compared with non-PGO).
- **Wheel size decreased by 1.32%** (12.71 MB to 12.54 MB compared with non-PGO), and by 14.11% compared with untuned PGO.
- **Release archive size decreased by 1.53%** (12.35 MB to 12.16 MB compared with non-PGO), and by 14.25% compared with untuned PGO.
- **Incremental language-server edits are 3.30% faster than untuned PGO**.
- **Linux x86-64 release build finishes in 11m28s on eight-core Depot**, compared with 12m59s on four-core Depot and 15m45s on the previous GitHub runner. The full-stack bottleneck shifts to Windows at 12m24s; other Linux targets retain their four-core runners.

### Stack

Additional platforms are covered in subsequent PRs:

- macOS ARM64: https://github.com/astral-sh/ty/pull/4216
- Windows x86-64: https://github.com/astral-sh/ty/pull/4217
- Linux ARM64: https://github.com/astral-sh/ty/pull/4218

Ruff and uv follow the same approach; see https://github.com/astral-sh/ruff/pull/27570 and https://github.com/astral-sh/uv/pull/21001.
