### PR TITLE
Enable PGO for macOS ARM64 ty releases

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,5 +6,6 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
+    - namespace-profile-macos-15
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -143,6 +143,9 @@ jobs:
             --target aarch64-apple-darwin \
             --target-dir "${{ github.workspace }}/ruff/target/ty-pgo" \
             --train-only
+
+          PROFILE_HOT_COUNT="$(cat "${{ github.workspace }}/ruff/target/ty-pgo/ty.profile-hot-count")"
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata -Cllvm-args=--profile-summary-hot-count=$PROFILE_HOT_COUNT" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels - aarch64"
@@ -153,7 +156,6 @@ jobs:
           rust-toolchain: ${{ steps.pgo-toolchain.outputs.toolchain }}
           args: --release --locked --out dist --compatibility pypi
         env:
-          RUSTFLAGS: "${{ env.RUSTFLAGS }} -Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata"
           CFLAGS: "-fno-profile-generate -fno-profile-use"
           CXXFLAGS: "-fno-profile-generate -fno-profile-use"
       - name: "Test wheel - aarch64"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -118,6 +118,10 @@ jobs:
   macos-aarch64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     runs-on: macos-15
+    env:
+      # Use Rust's bundled Mach-O LLD, which supports ICF.
+      # ICF reduces the macOS aarch64 ty binary size by ~0.7%.
+      RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -127,6 +131,18 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: arm64
+      - name: "Install LLVM profiling tools"
+        id: pgo-toolchain
+        working-directory: ruff
+        run: |
+          rustup component add llvm-tools-preview
+          echo "toolchain=$(rustc --version | cut -d ' ' -f2)" >> "$GITHUB_OUTPUT"
+      - name: "Train PGO ty"
+        run: |
+          python scripts/build_ty_pgo.py \
+            --target aarch64-apple-darwin \
+            --target-dir "${{ github.workspace }}/ruff/target/ty-pgo" \
+            --train-only
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels - aarch64"
@@ -134,11 +150,12 @@ jobs:
         with:
           maturin-version: v1.14.1
           target: aarch64
+          rust-toolchain: ${{ steps.pgo-toolchain.outputs.toolchain }}
           args: --release --locked --out dist --compatibility pypi
         env:
-          # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces the macOS aarch64 ty binary size by ~0.7%.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
+          RUSTFLAGS: "${{ env.RUSTFLAGS }} -Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata"
+          CFLAGS: "-fno-profile-generate -fno-profile-use"
+          CXXFLAGS: "-fno-profile-generate -fno-profile-use"
       - name: "Test wheel - aarch64"
         run: |
           pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -117,7 +117,7 @@ jobs:
 
   macos-aarch64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-15
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'namespace-profile-macos-15' || 'macos-15' }}
     env:
       # Use Rust's bundled Mach-O LLD, which supports ICF.
       # ICF reduces the macOS aarch64 ty binary size by ~0.7%.

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -131,6 +131,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: arm64
+      - name: "Install uv for PGO training"
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: "Install LLVM profiling tools"
         id: pgo-toolchain
         working-directory: ruff


### PR DESCRIPTION
## Summary

This PR enables PGO for ty's macOS ARM64 releases, following the approach outlined in https://github.com/astral-sh/ty/pull/4213. The existing linker configuration and safe identical-code folding are preserved.

Across seven held-out macOS projects, `ty check` finishes 5.0% faster and uses 7.1% less CPU; incremental language-server edits are 7.3% faster. The production executable is 3.6% smaller than without PGO, although the wheel and release archive are each 2.8% larger.

The macOS ARM64 release job uses the same Namespace runner as Ruff, reducing its full-stack PGO build from 23m 47s to 6m 39s (72%). Three Namespace builds finished in 6m 38s to 7m 59s; the previous Depot runner took 11m 20s.
