### PR TITLE
Enable PGO for Windows x86-64 ty releases

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,6 +7,6 @@ self-hosted-runner:
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
     - namespace-profile-macos-15
-    - depot-windows-2025-32
+    - namespace-profile-windows-2022-x86-64-16x32
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,5 +7,6 @@ self-hosted-runner:
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
     - namespace-profile-macos-15
+    - depot-windows-2025-32
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -190,7 +190,7 @@ jobs:
 
   windows:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'github-windows-2025-x86_64-16' || 'windows-latest' }}
+    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'github-windows-2025-x86_64-8' || 'windows-latest' }}
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -209,6 +209,26 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
+      - name: "Install LLVM profiling tools"
+        id: pgo-toolchain
+        if: ${{ matrix.platform.target == 'x86_64-pc-windows-msvc' }}
+        working-directory: ruff
+        shell: bash
+        run: |
+          rustup component add llvm-tools-preview
+          echo "toolchain=$(rustc --version | cut -d ' ' -f2)" >> "$GITHUB_OUTPUT"
+      - name: "Train PGO ty"
+        if: ${{ matrix.platform.target == 'x86_64-pc-windows-msvc' }}
+        shell: bash
+        run: |
+          export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C target-feature=+crt-static"
+
+          python scripts/build_ty_pgo.py \
+            --target "${{ matrix.platform.target }}" \
+            --target-dir "${{ github.workspace }}/ruff/target/ty-pgo" \
+            --train-only
+
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels"
@@ -216,10 +236,24 @@ jobs:
         with:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
+          rust-toolchain: ${{ steps.pgo-toolchain.outputs.toolchain }}
           args: --release --locked --out dist --compatibility pypi
         env:
           # aarch64 build fails, see https://github.com/PyO3/maturin/issues/2110
           XWIN_VERSION: 16
+      - name: "Verify static Windows runtime"
+        if: ${{ matrix.platform.target == 'x86_64-pc-windows-msvc' }}
+        working-directory: ruff
+        shell: bash
+        run: |
+          LLVM_READOBJ="$(rustc --print sysroot)/lib/rustlib/${{ matrix.platform.target }}/bin/llvm-readobj.exe"
+          IMPORTS_FILE="$RUNNER_TEMP/ty-coff-imports.txt"
+          "$LLVM_READOBJ" --coff-imports "target/${{ matrix.platform.target }}/release/ty.exe" > "$IMPORTS_FILE"
+
+          if grep -Eiq 'vcruntime[[:digit:]_]*\.dll|api-ms-win-crt-' "$IMPORTS_FILE"; then
+            echo "ty must not dynamically link the Visual C++ runtime" >&2
+            exit 1
+          fi
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -190,7 +190,7 @@ jobs:
 
   windows:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'github-windows-2025-x86_64-8' || 'windows-latest' }}
+    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'depot-windows-2025-32' || 'windows-latest' }}
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -228,7 +228,8 @@ jobs:
             --target-dir "${{ github.workspace }}/ruff/target/ty-pgo" \
             --train-only
 
-          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata" >> "$GITHUB_ENV"
+          PROFILE_HOT_COUNT="$(cat "${{ github.workspace }}/ruff/target/ty-pgo/ty.profile-hot-count")"
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/ruff/target/ty-pgo/ty.profdata -Cllvm-args=--profile-summary-hot-count=$PROFILE_HOT_COUNT" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py
       - name: "Build wheels"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -209,6 +209,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
+      - name: "Install uv for PGO training"
+        if: ${{ matrix.platform.target == 'x86_64-pc-windows-msvc' }}
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: "Install LLVM profiling tools"
         id: pgo-toolchain
         if: ${{ matrix.platform.target == 'x86_64-pc-windows-msvc' }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -190,7 +190,7 @@ jobs:
 
   windows:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: windows-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'github-windows-2025-x86_64-16' || 'windows-latest' }}
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -190,7 +190,7 @@ jobs:
 
   windows:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'depot-windows-2025-32' || 'windows-latest' }}
+    runs-on: ${{ github.repository == 'astral-sh/ty' && matrix.platform.target == 'x86_64-pc-windows-msvc' && 'namespace-profile-windows-2022-x86-64-16x32' || 'windows-latest' }}
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
## Summary

This PR enables PGO for ty's Windows x86-64 releases, following the approach outlined in https://github.com/astral-sh/ty/pull/4213. Both builds preserve static Visual C++ runtime linking.

On the Windows holdout set, `ty check` uses 19.7% less CPU and finishes 17.5% faster, while incremental language-server edits get 14.7% faster. The release binary gets 9.6% smaller, and the wheel and release archive each get 3.4% smaller.

Only the Windows x86-64 PGO job uses the same 16-core Namespace runner as Ruff, reducing the full-stack build from 26m 08s to 12m 24s (53%). The previous 32-core Depot runner took 14m 17s. With Linux x86-64 at 11m 28s and Linux ARM64 at 11m 37s, Windows is now the release bottleneck. The remaining Windows targets keep their existing runners.
