### PR TITLE
Use Depot runners for release builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,5 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
-    - depot-ubuntu-latest-4
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,8 @@
 self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
+    - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
+    - depot-ubuntu-latest-4
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -286,7 +286,7 @@ jobs:
 
   linux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         platform:
@@ -437,7 +437,7 @@ jobs:
 
   musllinux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   sdist:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -227,7 +227,7 @@ jobs:
 
   linux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-4
     strategy:
       matrix:
         target:
@@ -286,7 +286,7 @@ jobs:
 
   linux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     strategy:
       matrix:
         platform:
@@ -376,7 +376,7 @@ jobs:
 
   musllinux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         target:
@@ -437,7 +437,7 @@ jobs:
 
   musllinux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -227,7 +227,7 @@ jobs:
 
   linux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         target:


### PR DESCRIPTION
Move source distributions and Linux release builds onto four-core Ubuntu 24.04 Depot runners, matching the CPU count of the GitHub-hosted runners they replace while avoiding the runner queues observed in recent releases. Linux cross builds use the same runner size because they have not generally been the release bottleneck. Register the self-hosted runner label with actionlint.