### PR TITLE
Use an eight-core Ubuntu 24.04 runner for prek CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,8 +4,6 @@
 self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
-    - depot-ubuntu-latest-8
-    - depot-ubuntu-22.04-16
-    - depot-ubuntu-22.04-32
+    - depot-ubuntu-24.04-16
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,6 @@
 self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
-    - depot-ubuntu-24.04-16
+    - depot-ubuntu-24.04-8
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,6 @@
 self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
-    - depot-ubuntu-24.04-4
+    - depot-ubuntu-24.04-8
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,6 @@
 self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
-    - depot-ubuntu-24.04-8
+    - depot-ubuntu-24.04-4
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
   prek:
     name: "prek"
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
   prek:
     name: "prek"
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
   prek:
     name: "prek"
-    runs-on: depot-ubuntu-22.04-16
+    runs-on: depot-ubuntu-24.04-16
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
   prek:
     name: "prek"
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Previously, we ran `prek` on a 16-core Ubuntu 22.04 Depot runner. We now use an 8-core Ubuntu 24.04 runner and remove the unused Depot runner labels from the actionlint configuration.

| Runner | `prek` job | `Run prek` step | Approximate core-seconds |
| --- | ---: | ---: | ---: |
| 16 cores | 46s | 10s | 736 |
| 8 cores | 68s | 28s | 544 |
| 4 cores | 95s | 53s | 380 |

The 8-core runner uses approximately 26% fewer core-seconds than the previous 16-core runner while finishing 27 seconds sooner than the 4-core alternative. `prek` remains outside the overall CI critical path, where `python package` finished last in all eight recent completed runs on `main`.
