### PR TITLE
Validate the PGO pipeline in CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,7 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
+    - depot-ubuntu-24.04-16
     - depot-ubuntu-24.04-arm-8
     - namespace-profile-macos-15
     - namespace-profile-windows-2022-x86-64-16x32

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,27 @@ env:
   PACKAGE_NAME: ty
 
 jobs:
+  pgo:
+    name: "PGO"
+    runs-on: depot-ubuntu-24.04-16
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          architecture: x64
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: "Install LLVM profiling tools"
+        working-directory: ruff
+        run: rustup component add llvm-tools-preview
+      - name: "Run PGO pipeline"
+        run: python scripts/build_ty_pgo.py --debug
+
   python-package:
     name: "python package"
     runs-on: ubuntu-latest

--- a/scripts/build_ty_pgo.py
+++ b/scripts/build_ty_pgo.py
@@ -185,6 +185,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", help="Host-native Rust target triple")
     parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Use debug builds to validate the complete PGO pipeline",
+    )
+    parser.add_argument(
         "--target-dir",
         type=Path,
         help="Cargo target directory (default: CARGO_TARGET_DIR or ruff/target/ty-pgo)",
@@ -260,11 +265,12 @@ def main() -> None:
             environment.get("RUSTFLAGS"), f"-Cprofile-generate={profile_dir}"
         ),
     }
-    print("Building instrumented release ty", flush=True)
-    run(cargo_command(target), environment=instrumented_environment)
+    profile = "debug" if args.debug else "release"
+    print(f"Building instrumented {profile} ty", flush=True)
+    run(cargo_command(target, debug=args.debug), environment=instrumented_environment)
 
     binary_name = "ty.exe" if "windows" in target else "ty"
-    instrumented_binary = instrumented_target_dir / target / "release" / binary_name
+    instrumented_binary = instrumented_target_dir / target / profile / binary_name
     if not instrumented_binary.is_file():
         raise RuntimeError(f"Instrumented ty binary not found: {instrumented_binary}")
 
@@ -293,9 +299,11 @@ def main() -> None:
             f"-Cllvm-args=--profile-summary-hot-count={hot_count}",
         ),
     }
-    print("Building optimized release ty", flush=True)
-    run(cargo_command(target), environment=optimized_environment)
-    print(f"Optimized ty: {target_dir / target / 'release' / binary_name}", flush=True)
+    print(f"Building profile-guided {profile} ty", flush=True)
+    run(cargo_command(target, debug=args.debug), environment=optimized_environment)
+    print(
+        f"Profile-guided ty: {target_dir / target / profile / binary_name}", flush=True
+    )
 
 
 def train_ty(
@@ -892,11 +900,11 @@ def run_git_with_retry(command: list[str], *, environment: dict[str, str]) -> No
             time.sleep(delay)
 
 
-def cargo_command(target: str) -> list[str]:
+def cargo_command(target: str, *, debug: bool = False) -> list[str]:
     return [
         "cargo",
         "rustc",
-        "--release",
+        *(() if debug else ("--release",)),
         "--locked",
         "--package",
         "ty",


### PR DESCRIPTION
## Summary

This PR runs the complete PGO pipeline in CI on every pull request, catching changes that break ecosystem training or language-server profiling before they reach a release.

The new `--debug` flag performs the same dependency installation, instrumented build, ecosystem and language-server training, profile merging, hotness extraction, and profile-guided rebuild without the cost of release optimization.
