### PR TITLE
Update pymdown-extensions to 11.0.1 in docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -122,7 +122,7 @@ platformdirs==4.2.2
     #   mkdocs-get-deps
 pygments==2.18.0
     # via mkdocs-material
-pymdown-extensions==10.8.1
+pymdown-extensions==11.0.1
     # via mkdocs-material
 python-dateutil==2.9.0.post0
     # via ghp-import


### PR DESCRIPTION
Updates `pymdown-extensions` to address PYSEC-2026-1825, PYSEC-2026-2999, PYSEC-2026-3609, PYSEC-2026-3654 (GHSA-r6h4-mm7h-8pmq, GHSA-62q4-447f-wv8h, GHSA-9xwg-3r6f-jcx2, GHSA-gm37-52c6-37mw).

Evidence:
- `docs/requirements.txt` referenced `pymdown-extensions==10.8.1`
- `pip-audit` reported the advisories above for 10.8.1
- updated version: `11.0.1` (the pin for `mkdocs-material` in this file is 9.7.0, which allows `pymdown-extensions>=10.2`)

Validation:
- `pip-audit` no longer reports those advisories at 11.0.1
- `mkdocs build --strict -f mkdocs.yml` passes (the same command the docs workflow runs)
- full `pip install -r docs/requirements.txt` resolves with no conflicts

Scope: dependency/lockfile update only.
