### PR TITLE
Publish `ty_wasm` to npm

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -44,6 +44,9 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - name: "Install Rust toolchain"
+        # Run from `ruff`, so the target is added to the toolchain that
+        # `ruff/rust-toolchain.toml` pins rather than to the runner's default.
+        working-directory: ruff
         run: rustup target add wasm32-unknown-unknown
       - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
@@ -53,11 +56,12 @@ jobs:
         run: wasm-pack build --target ${{ matrix.target }} ruff/crates/ty_wasm
       - name: "Rename generated package"
         # `ty_wasm` is pinned at version 0.0.0 in the submodule, since ty's version only exists in
-        # this repository. Take it from the same place the wheels do.
+        # this repository. Take it from the same place the wheels do. `homepage` is inherited from
+        # the ruff workspace and would otherwise point at ruff's docs.
         run: |
           version="$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
           jq --arg name "@astral-sh/ty-wasm-${{ matrix.target }}" --arg version "$version" \
-            '.name = $name | .version = $version' \
+            '.name = $name | .version = $version | .homepage = "https://docs.astral.sh/ty"' \
             ruff/crates/ty_wasm/pkg/package.json > /tmp/package.json
           mv /tmp/package.json ruff/crates/ty_wasm/pkg/package.json
       - run: cp LICENSE ruff/crates/ty_wasm/pkg # wasm-pack does not put the LICENSE file in the pkg

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,69 @@
+# Build ty_wasm for npm.
+#
+# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a local
+# artifacts job within `cargo-dist`.
+name: "Build wasm"
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - .github/workflows/build-wasm.yml
+
+concurrency:
+  group: build-wasm-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  ACTIONS_CACHE_MODE: none
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  build:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
+    # `ty_wasm` links the entire type checker and the vendored typeshed stubs under fat LTO,
+    # so this needs more than a standard runner.
+    runs-on: depot-ubuntu-24.04-4
+    strategy:
+      matrix:
+        target: [web, bundler, nodejs]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - name: "Install Rust toolchain"
+        run: rustup target add wasm32-unknown-unknown
+      - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+        with:
+          version: v0.13.1
+      - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
+      - name: "Run wasm-pack build"
+        run: wasm-pack build --target ${{ matrix.target }} ruff/crates/ty_wasm
+      - name: "Rename generated package"
+        # `ty_wasm` is pinned at version 0.0.0 in the submodule, since ty's version only exists in
+        # this repository. Take it from the same place the wheels do.
+        run: |
+          version="$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          jq --arg name "@astral-sh/ty-wasm-${{ matrix.target }}" --arg version "$version" \
+            '.name = $name | .version = $version' \
+            ruff/crates/ty_wasm/pkg/package.json > /tmp/package.json
+          mv /tmp/package.json ruff/crates/ty_wasm/pkg/package.json
+      - run: cp LICENSE ruff/crates/ty_wasm/pkg # wasm-pack does not put the LICENSE file in the pkg
+      - name: "Upload wasm artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Avoid prefixing the name with `artifacts-` here to exclude it from the GitHub release.
+          name: wasm-npm-${{ matrix.target }}
+          path: ruff/crates/ty_wasm/pkg

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -1,0 +1,44 @@
+# Publish ty_wasm to npm.
+#
+# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a publish
+# job within `cargo-dist`.
+name: "Publish wasm"
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+env:
+  ACTIONS_CACHE_MODE: none
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      # For npm's trusted publishing.
+      id-token: write
+    strategy:
+      matrix:
+        target: [web, bundler, nodejs]
+      fail-fast: false
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wasm-npm-${{ matrix.target }}
+          path: pkg
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          package-manager-cache: false
+          node-version: 24.19.0
+          registry-url: "https://registry.npmjs.org"
+      - name: "Publish (dry-run)"
+        if: ${{ inputs.plan == '' || fromJson(inputs.plan).announcement_tag_is_implicit }}
+        run: npm publish --dry-run pkg/
+      - name: "Publish"
+        if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+        run: npm publish --provenance --access public pkg/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,24 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
+  custom-build-wasm:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run' }}
+    uses: $/.github/workflows/build-wasm.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    permissions:
+      "contents": "read"
+
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
       - custom-build-binaries
       - custom-build-docker
+      - custom-build-wasm
     permissions:
       "contents": "read"
     runs-on: "depot-ubuntu-latest-4"
@@ -210,9 +222,10 @@ jobs:
       - plan
       - custom-build-binaries
       - custom-build-docker
+      - custom-build-wasm
       - build-global-artifacts
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-binaries.result == 'skipped' || needs.custom-build-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-binaries.result == 'skipped' || needs.custom-build-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') && (needs.custom-build-wasm.result == 'skipped' || needs.custom-build-wasm.result == 'success') }}
     permissions:
       "contents": "read"
     env:
@@ -276,6 +289,21 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
+  custom-publish-wasm:
+    needs:
+      - plan
+      - host
+      - release-gate
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: $/.github/workflows/publish-wasm.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
+    permissions:
+      "contents": "read"
+      "id-token": "write"
+
   # Create a GitHub Release while uploading all files to it
   announce:
     needs:
@@ -283,10 +311,11 @@ jobs:
       - host
       - release-gate
       - custom-publish-pypi
+      - custom-publish-wasm
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-wasm.result == 'skipped' || needs.custom-publish-wasm.result == 'success') }}
     runs-on: "depot-ubuntu-latest-4"
     environment:
       name: release

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -60,13 +60,13 @@ github-attestations-filters = ["*.json", "*.sh", "*.ps1", "*.zip", "*.tar.gz"]
 # Whether CI should include auto-generated code to build local artifacts
 build-local-artifacts = false
 # Local artifacts jobs to run in CI
-local-artifacts-jobs = ["./build-binaries", "./build-docker"]
+local-artifacts-jobs = ["./build-binaries", "./build-docker", "./build-wasm"]
 # Publish jobs to run in CI
-publish-jobs = ["./publish-pypi"]
+publish-jobs = ["./publish-pypi", "./publish-wasm"]
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./notify-dependents", "./publish-docs", "./publish-versions", "./publish-mirror"]
 # Custom permissions for GitHub Jobs
-github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-mirror" = { contents = "read" } }
+github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-wasm" = { contents = "read", id-token = "write" }, "publish-mirror" = { contents = "read" } }
 # Whether to install an updater program
 install-updater = false
 # Path that installers should place binaries in


### PR DESCRIPTION
## Summary

Closes #4007.

Adds a `build-wasm` local-artifacts job and a `publish-wasm` publish job to the `dist` pipeline, publishing `ty_wasm` as `@astral-sh/ty-wasm-web`, `@astral-sh/ty-wasm-bundler` and `@astral-sh/ty-wasm-nodejs`. Both workflows are ports of ruff's `build-wasm.yml` and `publish-wasm.yml`.

The build side needed little. `ty_wasm` is already built with `wasm-pack` on every push to `main` for the playground, already lints under `--target wasm32-unknown-unknown`, and already runs `wasm-pack test --node` in ruff's CI.

Versioning is the one place this can't follow ruff. `ruff_wasm/Cargo.toml` carries the real version and is bumped in-repo, so `wasm-pack` writes it into `package.json`. `ty_wasm` is pinned at `0.0.0`, ty's version exists only in this repository, and `scripts/release.sh` aborts on a dirty submodule, so rooster can't write to `ruff/crates/ty_wasm/Cargo.toml`. The build job instead reads the version from `pyproject.toml`, where the wheels get theirs, and injects it into the generated `package.json` along with the name. The same step corrects `homepage`, which `ty_wasm` inherits from the ruff workspace and which would otherwise point the packages at ruff's documentation. Taking it from `announcement_tag` in the dist plan, or bumping `ty_wasm`'s `Cargo.toml` upstream, would work too if you'd prefer either.

Three other deviations from ruff:

- `rustup target add` runs with `working-directory: ruff`. The toolchain pin lives in the submodule rather than at this repository's root, so at the root the target lands on the runner's default toolchain and `wasm-pack` then fails to build.
- The build runs on `depot-ubuntu-24.04-4`. `ty_wasm` links the whole type checker and the vendored typeshed under `lto = "fat"`, so it's a good deal heavier than `ruff_wasm`.
- `publish-wasm` gets `contents: read` and `id-token: write`, without ruff's `packages: write`. `npm publish` doesn't touch GitHub Packages, but I may be missing something.

Trusted publishers still need setting up on npmjs for the three names, which are unregistered today. Until that happens the publish job will fail on a real release; dry-runs are unaffected.

For size reference, each package comes out at 7.1 MB packed and 17.1 MB unpacked, against 11.05 MB unpacked for the published `@astral-sh/ruff-wasm-web`.

One omission: `ty_wasm` has no `README.md`, so the npm pages would render empty. That belongs beside the crate in `astral-sh/ruff` rather than here, so it isn't in this PR. I can open it separately.

## Test Plan

`release.yml` is hand-maintained (`allow-dirty = ["ci"]`), so I didn't regenerate it. I generated a clean copy from the updated `dist-workspace.toml` with dist 0.31.0 and diffed it against this branch. The only differences are the hand-patches already present, plus the same three that the sibling jobs already carry applied to the new ones: `$/` in `uses:`, explicit `contents: read` on the build job, and `release-gate` in the publish job's `needs`. Both new jobs otherwise match ruff's `custom-build-wasm` and `custom-publish-wasm`, apart from the permissions noted above.

`prek run` (zizmor, prettier, check-github-workflows) and `prek run actionlint --hook-stage=manual` pass, and `dist plan` accepts the updated config. The `jq` rename step was run against the real `package.json` from the published `@astral-sh/ruff-wasm-web` tarball; it replaces name and version and leaves every other field alone.

I ran both workflows end to end in a container approximating the ubuntu-24.04 runner (rustup with a preinstalled stable toolchain, wasm-pack v0.13.1, Node 24), driving them with the `run:` bodies extracted from the YAML. All three targets build and `npm publish --dry-run` cleanly, the version resolves to 0.0.73, and `LICENSE` lands in the tarball. Two limits on that: the container approximates the runner rather than being it, and the three targets ran sequentially in one workspace, so cargo's cache was warm after the first. The publish path past `--dry-run` is unexercised.

---

Disclaimer: this was put together with AI assistance (Claude Code).

