### PR TITLE
Fix documented Python package build command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ uv run --only-group dev --locked prek install
 The Python package can be built with any Python build frontend (Maturin is used as a backend), e.g.:
 
 ```shell
-uv build
+uv build --build
 ```
 
 ## Updating the Ruff commit


### PR DESCRIPTION
## Summary

Use `uv build --build` to override the repository's `no-build = true` setting when contributors build the Python package.

Fixes #4361.

## Test plan

Documentation-only change; no new tests. Verified that this works to build ty.
