### PR TITLE
Improve `uv-lock` pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     hooks:
       - id: uv-lock
         priority: 0
+        args: [--check, --refresh, --default-index=https://pypi.org/simple]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0


### PR DESCRIPTION
## Summary

Same as https://github.com/astral-sh/ruff/pull/28078. `--check` gives a better error message when the hook fails in CI; `--refresh` means the hook will reject manual updates to the lockfile that don't abide by the cooldown policy.

## Test Plan

`uv run --locked --only-group=dev prek run --all-files`