### PR TITLE
Update `strict-literal-narrowing` to `strict-equality-semantics`

### DIFF
--- a/docs/coming-from-mypy-or-pyright.md
+++ b/docs/coming-from-mypy-or-pyright.md
@@ -81,7 +81,7 @@ possibly-missing-attribute = "warn"
 possibly-missing-import = "warn"
 
 [tool.ty.analysis]
-strict-literal-narrowing = true
+strict-equality-semantics = true
 strict-generic-narrowing = true
 
 [tool.ruff.lint]


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The "coming from mypy or pyright" page still references `strict-literal-narrowing`, but it was renamed to `strict-equality-semantics` in https://github.com/astral-sh/ruff/pull/27031.

## Test Plan

<!-- How was it tested? -->

N/A