### PR TITLE
fix: update broken registry.bazel.build/docs URLs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -169,7 +169,7 @@ The following tags are available:
 
 ### Using ty with Bazel
 
-[`aspect_rules_lint`](https://registry.bazel.build/docs/aspect_rules_lint#function-lint_ty_aspect)
+[`aspect_rules_lint`](https://registry.bazel.build/modules/aspect_rules_lint/latest/docs/lint/ty.bzl/lint_ty_aspect)
 provides a Bazel lint aspect that runs ty. See its documentation for setup instructions.
 
 ## Adding ty to your editor


### PR DESCRIPTION
## Summary

The `registry.bazel.build/docs/<name>` URL pattern returns 404 and is no longer valid.

The correct URL format is now `registry.bazel.build/modules/<name>/latest/docs`.

This was identified across multiple Bazel rule repositories — see https://github.com/hermeticbuild/rules_rs/pull/235 for the original fix.

## Changes

- Replaced broken `/docs/aspect_rules_lint` URL with `/modules/aspect_rules_lint/latest/docs`
- Replaced symbol anchor with explicit path:
  - `#function-lint_ty_aspect` → `/lint/ty.bzl/lint_ty_aspect`