### PR TITLE
Allow Ruff to format our docs examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2252,6 +2252,7 @@ class Foo:
     def __init__(self) -> None:
         self.value = 1
 
+
 reveal_type(Foo().value)  # revealed: int
 Foo().value = "x"  # error: [invalid-assignment]
 ```

--- a/docs/features/type-system.md
+++ b/docs/features/type-system.md
@@ -30,10 +30,7 @@ def output_as_json(obj: Serializable) -> str:
     if isinstance(obj, Versioned):
         reveal_type(obj)  # reveals: Serializable & Versioned
 
-        return str({
-            "data": obj.serialize_json(),
-            "version": obj.version
-        })
+        return str({"data": obj.serialize_json(), "version": obj.version})
     else:
         return obj.serialize_json()
 ```
@@ -71,8 +68,10 @@ protocol, accounting for the possibility of subclasses of `Animal` that add a `n
 class Person:
     name: str
 
+
 class Animal:
     species: str
+
 
 def greet(being: Person | Animal | None):
     if hasattr(being, "name"):
@@ -103,8 +102,9 @@ if TYPE_CHECKING:
 
     type SerializableVersioned = Intersection[Serializable, Versioned]
 
+
 def output_as_json(obj: SerializableVersioned) -> str:
-    ...
+    raise NotImplementedError
 ```
 
 (Full example in the [playground](https://play.ty.dev/f003e901-0e45-4f45-9759-d6db9d5e5f66))
@@ -123,6 +123,7 @@ of `list[Unknown]`:
 ```py
 @final
 class Item: ...
+
 
 def process(items: Item | list[Item]):
     if isinstance(items, list):
@@ -158,8 +159,10 @@ from pydantic import BaseModel
 
 PYDANTIC_V2 = pydantic.__version__.startswith("2.")
 
+
 class Person(BaseModel):
     name: str
+
 
 def to_json(person: Person):
     if PYDANTIC_V2:

--- a/docs/features/type-system.md
+++ b/docs/features/type-system.md
@@ -103,8 +103,7 @@ if TYPE_CHECKING:
     type SerializableVersioned = Intersection[Serializable, Versioned]
 
 
-def output_as_json(obj: SerializableVersioned) -> str:
-    raise NotImplementedError
+def output_as_json(obj: SerializableVersioned) -> str: ...
 ```
 
 (Full example in the [playground](https://play.ty.dev/f003e901-0e45-4f45-9759-d6db9d5e5f66))

--- a/docs/reference/typing-faq.md
+++ b/docs/reference/typing-faq.md
@@ -69,8 +69,11 @@ produces a new type, ty replaces the non-convergent part with `Divergent`.
 For example, each iteration of this loop wraps `x` in another list:
 
 ```py
+import random
+
+
 def some_condition() -> bool:
-    ...
+    return random.choice([True, False])
 
 
 x = 1
@@ -98,7 +101,8 @@ includes a special rule for numeric types where an `int` can be used wherever a 
 def circle_area(radius: float) -> float:
     return 3.14 * radius * radius
 
-circle_area(2)      # OK: int is allowed where float is expected
+
+circle_area(2)  # OK: int is allowed where float is expected
 ```
 
 This rule is a special case, since `int` is not actually a subclass of `float`. A `float` annotation
@@ -143,10 +147,12 @@ The starred spellings only appear in ty's output; they cannot be used in Python 
     else:
         JustFloat = float
 
+
     def only_actual_floats_allowed(f: JustFloat) -> None: ...
 
+
     only_actual_floats_allowed(1.0)  # OK
-    only_actual_floats_allowed(1)    # error: invalid-argument-type
+    only_actual_floats_allowed(1)  # error: invalid-argument-type
     ```
 
     ([Full example in the playground](https://play.ty.dev/fb034780-3ba7-4c6a-9449-5b0f44128bab))
@@ -164,8 +170,10 @@ the case. The reason for this is mutability:
 ```py
 # Setup of `Entry`, `Directory`, and `File` classes (1)
 
+
 def modify(entries: list[Entry]):
-    entries.append(File("README.txt")) # mutation
+    entries.append(File("README.txt"))  # mutation
+
 
 directories: list[Directory] = [Directory("Downloads"), Directory("Documents")]
 modify(directories)  # ty emits an error on this call
@@ -176,21 +184,27 @@ modify(directories)  # ty emits an error on this call
     ```py
     from dataclasses import dataclass
 
+
     @dataclass
     class Entry:
-         path: str
-         def size_bytes(self) -> int: ...
+        path: str
+
+        def size_bytes(self) -> int: ...
+
 
     @dataclass
     class Directory(Entry):
         def children(self) -> list[Entry]: ...
 
+
     @dataclass
     class File(Entry):
         def content(self) -> bytes: ...
 
+
     def modify(entries: list[Entry]):
-        entries.append(File("README.txt")) # mutation
+        entries.append(File("README.txt"))  # mutation
+
 
     directories: list[Directory] = [Directory("Downloads"), Directory("Documents")]
     modify(directories)  # ty emits an error on this call
@@ -225,6 +239,7 @@ required:
 ```py
 def total_size_bytes(entries: list[Entry]) -> int:
     return sum(entry.size_bytes() for entry in entries)
+
 
 # inferred as `list[Directory]`
 media_entries = [Directory("Pictures"), Directory("Videos")]
@@ -318,7 +333,7 @@ the developer experience around this in the future.
 
 
     def retry(times: int, operation: FunctionLikeCallable[[], bool]) -> bool:
-        ...
+        raise NotImplementedError
     ```
 
     You can check out the full example [here](https://play.ty.dev/7a1ea4ab-04e1-4271-adf5-ddc3a5d2fcfd),

--- a/docs/reference/typing-faq.md
+++ b/docs/reference/typing-faq.md
@@ -69,11 +69,7 @@ produces a new type, ty replaces the non-convergent part with `Divergent`.
 For example, each iteration of this loop wraps `x` in another list:
 
 ```py
-import random
-
-
-def some_condition() -> bool:
-    return random.choice([True, False])
+def some_condition() -> bool: ...
 
 
 x = 1
@@ -332,8 +328,7 @@ the developer experience around this in the future.
         FunctionLikeCallable = Callable
 
 
-    def retry(times: int, operation: FunctionLikeCallable[[], bool]) -> bool:
-        raise NotImplementedError
+    def retry(times: int, operation: FunctionLikeCallable[[], bool]) -> bool: ...
     ```
 
     You can check out the full example [here](https://play.ty.dev/7a1ea4ab-04e1-4271-adf5-ddc3a5d2fcfd),

--- a/docs/suppression.md
+++ b/docs/suppression.md
@@ -18,6 +18,8 @@ a = 10 + "test"  # ty: ignore[unsupported-operator]
 Rule violations spanning multiple lines can be suppressed by adding the comment at the end of the
 violation's first or last line:
 
+<!-- fmt:off -->
+
 ```py
 def sum_three_numbers(a: int, b: int, c: int) -> int: ...
 
@@ -35,6 +37,8 @@ sum_three_numbers(
     2
 )  # ty: ignore[missing-argument]
 ```
+
+<!-- fmt:on -->
 
 To suppress multiple violations on a single line, enumerate each rule separated by a comma:
 
@@ -106,8 +110,10 @@ to suppress all violations inside a function.
 ```python
 from typing import no_type_check
 
+
 def sum_three_numbers(a: int, b: int, c: int) -> int:
     return a + b + c
+
 
 @no_type_check
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,13 +73,6 @@ docs = {requires-python = ">=3.12"}
 extend-exclude = ["ruff"]
 per-file-target-version = { "scripts/**" = "py313" }
 
-[tool.ruff.format]
-exclude = [
-    "CHANGELOG.md",
-    # Code samples in our docs often use intentional formatting for educational reasons.
-    "docs/**/*.md",
-]
-
 [tool.ruff.lint]
 select = [
     "E",   # pycodestyle (error)


### PR DESCRIPTION
## Summary

It feels like a bit of a bad sign for the feature if we can't enable Ruff's markdown formatting on some of our own repos. But I think we can -- most of the formatting changes Ruff wants to make here seem like clear improvements to me. The one clear exception is in `suppression.md`, but there it's fairly easy to suppress Ruff's formatting with an HTML comment that will be invisible to readers of the docs.

## Test Plan

`uvx prek run -a` passes