### PR TITLE
[ty] Embed archive checksums in the shell installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,63 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
+  # The custom binary jobs produce checksum sidecars outside cargo-dist.
+  # Include them in a local manifest before generating the installers.
+  generate-checksum-manifest:
+    needs:
+      - plan
+      - custom-build-binaries
+    if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run' }}
+    permissions:
+      "contents": "read"
+    runs-on: "depot-ubuntu-latest-4"
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: false
+      - name: Install cached dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - name: Generate local dist manifest
+        shell: bash
+        env:
+          DIST_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
+        run: |
+          dist_args=()
+          if [[ -n "$DIST_TAG_FLAG" ]]; then
+            dist_args+=("$DIST_TAG_FLAG")
+          fi
+          temp_manifest=target/local-dist-manifest.json.tmp
+          dist manifest "${dist_args[@]}" --output-format=json --no-local-paths --artifacts=local > "$temp_manifest"
+          uv run --locked scripts/patch-dist-manifest-checksums.py --manifest "$temp_manifest" --artifacts-dir target/distrib
+          mv "$temp_manifest" target/distrib/local-dist-manifest.json
+      - name: Upload synthesized local dist manifest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: artifacts-build-local-manifest
+          path: target/distrib/local-dist-manifest.json
+
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
       - custom-build-binaries
       - custom-build-docker
+      - generate-checksum-manifest
     permissions:
       "contents": "read"
     runs-on: "depot-ubuntu-latest-4"
@@ -211,8 +262,9 @@ jobs:
       - custom-build-binaries
       - custom-build-docker
       - build-global-artifacts
-    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-binaries.result == 'skipped' || needs.custom-build-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') }}
+      - generate-checksum-manifest
+    # Require checksums for all built archives before publishing. Other build jobs may be skipped.
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && needs.generate-checksum-manifest.result == 'success' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-binaries.result == 'skipped' || needs.custom-build-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') }}
     permissions:
       "contents": "read"
     env:

--- a/scripts/patch-dist-manifest-checksums.py
+++ b/scripts/patch-dist-manifest-checksums.py
@@ -1,0 +1,58 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+
+"""Add sidecar SHA-256 checksums to a cargo-dist local manifest.
+
+The release workflow builds archives outside cargo-dist. Its global installer
+generation needs their checksums in the manifest, so copy them from the sidecars
+uploaded by the binary build jobs. Require a checksum for every downloaded
+executable archive to avoid publishing installers with partial checksum coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def read_sha256(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    if len(lines) != 1:
+        raise ValueError(f"expected one checksum in {path}")
+    checksum = lines[0].split()[0]
+    if re.fullmatch(r"[0-9a-fA-F]{64}", checksum) is None:
+        raise ValueError(f"invalid SHA-256 checksum in {path}: {checksum!r}")
+    return checksum.lower()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    patched = 0
+    for artifact_name, artifact in manifest["artifacts"].items():
+        if artifact["kind"] != "executable-zip":
+            continue
+        # The manifest can include targets omitted by the custom binary jobs.
+        if not (args.artifacts_dir / artifact_name).is_file():
+            continue
+        checksum = read_sha256(args.artifacts_dir / f"{artifact_name}.sha256")
+        artifact.setdefault("checksums", {})["sha256"] = checksum
+        patched += 1
+
+    if patched == 0:
+        raise ValueError(f"no executable archives found in {args.artifacts_dir}")
+
+    args.manifest.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"patched {patched} archive checksum(s) in {args.manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch-dist-manifest-checksums.py.lock
+++ b/scripts/patch-dist-manifest-checksums.py.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"


### PR DESCRIPTION
Release archives already have `.sha256` files, but the custom binary build jobs don't put those hashes in cargo-dist's manifest. The generated shell installer therefore has no expected archive hashes to check.

Add a job that imports the built archives' checksums into a local manifest before cargo-dist generates the installers. Run the helper through uv with a script lockfile, require a valid sidecar for every downloaded executable archive, and require the job to succeed before hosting the release.
