### PR TITLE
Fix code block syntax highlighting in rules.md

### DIFF
--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -110,7 +110,7 @@ class are explicitly declared.
 **Examples**
 
 
-```py
+```python
 from typing import ClassVar, Protocol
 
 


### PR DESCRIPTION
The language specifier has been fixed to ensure correct code display (some extensions in VS Code for `.md` do not support `py`, only `python`).