### PR TITLE
Remove redundant --exit-non-zero-on-fix from Ruff hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
     rev: 321478e58f4938179c6b86e4ddfa923d1547a49b # frozen: v0.16.6
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix]
         types_or: [python, pyi]
         require_serial: true
         priority: 2


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Remove `--exit-non-zero-on-fix` from the Ruff hook, keeping `--fix`. prek already fails when a hook modifies files.
This follows https://github.com/astral-sh/ruff-pre-commit/pull/57.
## Test Plan

<!-- How was it tested? -->
- `uv run --only-group dev --locked prek validate-config .pre-commit-config.yaml`
- `uv run --only-group dev --locked prek run --files .pre-commit-config.yaml`