### PR TITLE
Use paid GitHub-hosted runners for Linux

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,7 @@ self-hosted-runner:
     - depot-ubuntu-24.04-8
     - depot-ubuntu-24.04-16
     - depot-ubuntu-24.04-arm-8
+    - github-ubuntu-24.04-x86_64-4
     - namespace-profile-macos-15
     - namespace-profile-windows-2022-x86-64-16x32
     - github-windows-2025-x86_64-8

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   docker-build:
     name: Build Docker image (ghcr.io/astral-sh/ty) for ${{ matrix.platform }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit && 'release' || '' }}
     strategy:
@@ -111,7 +111,7 @@ jobs:
 
   docker-publish:
     name: Publish Docker image (ghcr.io/astral-sh/ty)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     needs:
@@ -181,7 +181,7 @@ jobs:
 
   docker-publish-extra:
     name: Publish additional Docker image based on ${{ matrix.image-mapping }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     needs:
@@ -289,7 +289,7 @@ jobs:
   # This works by annotating the original digests (previously non-annotated) which triggers an update to ghcr.io
   docker-republish:
     name: Annotate Docker image (ghcr.io/astral-sh/ty)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
   python-package:
     name: "python package"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -95,7 +95,7 @@ jobs:
 
   generated-check:
     name: "Check generated files unedited"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -121,7 +121,7 @@ jobs:
   docs:
     timeout-minutes: 10
     name: "mkdocs"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/daily_property_tests.yml
+++ b/.github/workflows/daily_property_tests.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   property_tests:
     name: Property tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 20
     # Don't run the cron job on forks:
     if: ${{ github.repository == 'astral-sh/ty' || github.event_name != 'schedule' }}
@@ -54,7 +54,7 @@ jobs:
 
   create-issue-on-failure:
     name: Create an issue if the daily property test run surfaced any bugs
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     needs: property_tests
     if: ${{ github.repository == 'astral-sh/ty' && always() && github.event_name == 'schedule' && needs.property_tests.result == 'failure' }}
     permissions:

--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -19,7 +19,7 @@ jobs:
     name: Notify dependents
     environment:
       name: release
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - name: "Update pre-commit mirror"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ jobs:
   mkdocs:
     environment:
       name: release
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   publish-mirror:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     env:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   pypi-publish:
     name: Upload to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     permissions:

--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   publish-versions:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: release
     env:
       VERSION: ${{ fromJson(inputs.plan).announcement_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     # N.B. This name should not change, it is used for downstream checks.
     name: release-gate
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.tag != 'dry-run' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'astral-sh/ty' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     # This environment requires a 2-factor approval, i.e., the workflow must be approved by another
     # team member. GitHub fires approval events on every job that deploys to an environment, so we
     # have a dedicated environment for this purpose instead of using the `release` environment.


### PR DESCRIPTION
The standard Linux jobs share the organization's GitHub-hosted concurrency limit. Route them to the existing four-core GitHub-hosted larger runners. Forks continue to use the standard runners, and the existing Depot, Namespace, Windows, and macOS runner choices are unchanged.